### PR TITLE
Validate that CR name is 'cluster'

### DIFF
--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -125,7 +125,7 @@ const (
 )
 
 const (
-	// Validation represents the fact that the validation of
+	// ValidationSucceededReason represents the fact that the validation of
 	// the resource has succeeded.
 	ValidationSucceededReason string = "ValidationSucceeded"
 

--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -125,11 +125,11 @@ const (
 )
 
 const (
-	// ReconciliationSucceededReason represents the fact that the reconciliation of
+	// Validation represents the fact that the validation of
 	// the resource has succeeded.
-	ReconciliationSucceededReason string = "ReconciliationSucceeded"
+	ValidationSucceededReason string = "ValidationSucceeded"
 
-	// ReconciliationFailedReason represents the fact that the reconciliation of
+	// ValidationFailedReason represents the fact that the validation of
 	// the resource has failed.
-	ReconciliationFailedReason string = "ReconciliationFailed"
+	ValidationFailedReason string = "ValidationFailed"
 )

--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -119,3 +119,17 @@ type RegistryCert struct {
 	// Certificate is the certificate for the trusted certificate authority associated with the registry.
 	Certificate string `json:"certificate"`
 }
+
+const (
+	ConditionTypeReady string = "Ready"
+)
+
+const (
+	// ReconciliationSucceededReason represents the fact that the reconciliation of
+	// the resource has succeeded.
+	ReconciliationSucceededReason string = "ReconciliationSucceeded"
+
+	// ReconciliationFailedReason represents the fact that the reconciliation of
+	// the resource has failed.
+	ReconciliationFailedReason string = "ReconciliationFailed"
+)

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -83,7 +83,7 @@ func validateCR(relocation *rhsysenggithubiov1beta1.ClusterRelocation) error {
 		err := fmt.Errorf("invalid name: %s. CR name must be: cluster", relocation.Name)
 		readyCondition := metav1.Condition{
 			Status:             metav1.ConditionFalse,
-			Reason:             rhsysenggithubiov1beta1.ReconciliationFailedReason,
+			Reason:             rhsysenggithubiov1beta1.ValidationFailedReason,
 			Message:            err.Error(),
 			Type:               rhsysenggithubiov1beta1.ConditionTypeReady,
 			ObservedGeneration: relocation.GetGeneration(),
@@ -94,8 +94,7 @@ func validateCR(relocation *rhsysenggithubiov1beta1.ClusterRelocation) error {
 
 	readyCondition := metav1.Condition{
 		Status:             metav1.ConditionTrue,
-		Reason:             rhsysenggithubiov1beta1.ReconciliationSucceededReason,
-		Message:            "reconciliation succeeded",
+		Reason:             rhsysenggithubiov1beta1.ValidationSucceededReason,
 		Type:               rhsysenggithubiov1beta1.ConditionTypeReady,
 		ObservedGeneration: relocation.GetGeneration(),
 	}

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -69,10 +69,10 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	err = validateCR(relocation)
 	if err != nil {
-		logger.Error(err, "Could not reconcile ClusterRelocation")
+		logger.Error(err, "Could not validate ClusterRelocation")
 		return ctrl.Result{}, nil
 	} else {
-		logger.Info("reconciliation succeeded")
+		logger.Info("validation succeeded")
 	}
 
 	return ctrl.Result{}, nil

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -18,13 +18,18 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
+	"github.com/go-logr/logr"
 )
 
 // ClusterRelocationReconciler reconciles a ClusterRelocation object
@@ -47,11 +52,62 @@ type ClusterRelocationReconciler struct {
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
 func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	_ = log.FromContext(ctx)
+	logger := log.FromContext(ctx)
 
-	// TODO(user): your logic here
+	relocation := &rhsysenggithubiov1beta1.ClusterRelocation{}
+
+	err := r.Get(ctx, req.NamespacedName, relocation)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Info("ClusterRelocation resource not found. Ignoring since object must be deleted")
+			return ctrl.Result{}, nil
+		}
+		logger.Error(err, "Failed to get ClusterRelocation")
+		return ctrl.Result{}, err
+	}
+	defer r.updateStatus(ctx, relocation, logger)
+
+	err = validateCR(relocation)
+	if err != nil {
+		logger.Error(err, "Could not reconcile ClusterRelocation")
+		return ctrl.Result{}, nil
+	} else {
+		logger.Info("reconciliation succeeded")
+	}
 
 	return ctrl.Result{}, nil
+}
+
+func validateCR(relocation *rhsysenggithubiov1beta1.ClusterRelocation) error {
+	if relocation.Name != "cluster" {
+		err := fmt.Errorf("invalid name: %s. CR name must be: cluster", relocation.Name)
+		readyCondition := metav1.Condition{
+			Status:             metav1.ConditionFalse,
+			Reason:             rhsysenggithubiov1beta1.ReconciliationFailedReason,
+			Message:            err.Error(),
+			Type:               rhsysenggithubiov1beta1.ConditionTypeReady,
+			ObservedGeneration: relocation.GetGeneration(),
+		}
+		apimeta.SetStatusCondition(&relocation.Status.Conditions, readyCondition)
+		return err
+	}
+
+	readyCondition := metav1.Condition{
+		Status:             metav1.ConditionTrue,
+		Reason:             rhsysenggithubiov1beta1.ReconciliationSucceededReason,
+		Message:            "reconciliation succeeded",
+		Type:               rhsysenggithubiov1beta1.ConditionTypeReady,
+		ObservedGeneration: relocation.GetGeneration(),
+	}
+	apimeta.SetStatusCondition(&relocation.Status.Conditions, readyCondition)
+	return nil
+}
+
+func (r *ClusterRelocationReconciler) updateStatus(ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) {
+	err := r.Status().Update(ctx, relocation)
+	if err != nil {
+		logger.Error(err, "Failed to update Status")
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.6.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
-	github.com/go-logr/logr v1.2.3 // indirect
+	github.com/go-logr/logr v1.2.3
 	github.com/go-logr/zapr v1.2.3 // indirect
 	github.com/go-openapi/jsonpointer v0.19.5 // indirect
 	github.com/go-openapi/jsonreference v0.20.0 // indirect


### PR DESCRIPTION
Fixes https://github.com/RHsyseng/cluster-relocation-operator/issues/16

This adds a `validateCR` function which checks that the CR name is `cluster`. It updates the `Ready` condition of the CR based on whether this validation succeeded or not.

The `validateCR` could be expanded in the future to add other validations.

Example of success:
```
apiVersion: rhsyseng.github.io/v1beta1
kind: ClusterRelocation
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"rhsyseng.github.io/v1beta1","kind":"ClusterRelocation","metadata":{"annotations":{},"name":"cluster"},"spec":{"domain":"hello.com"}}
  creationTimestamp: "2023-05-30T18:10:55Z"
  generation: 1
  name: cluster
  resourceVersion: "423570"
  uid: 4bd05411-e61f-404e-818c-ad6b0e689bf3
spec:
  domain: hello.com
status:
  conditions:
  - lastTransitionTime: "2023-05-30T18:10:57Z"
    message: ""
    observedGeneration: 1
    reason: ValidationSucceeded
    status: "True"
    type: Ready
```

Example of failure:
```
apiVersion: rhsyseng.github.io/v1beta1
kind: ClusterRelocation
metadata:
  annotations:
    kubectl.kubernetes.io/last-applied-configuration: |
      {"apiVersion":"rhsyseng.github.io/v1beta1","kind":"ClusterRelocation","metadata":{"annotations":{},"name":"testname"},"spec":{"domain":"hello.com"}}
  creationTimestamp: "2023-05-30T18:11:16Z"
  generation: 1
  name: testname
  resourceVersion: "423689"
  uid: d2389bf5-f377-4df1-a148-9a6d023b24e8
spec:
  domain: hello.com
status:
  conditions:
  - lastTransitionTime: "2023-05-30T18:11:19Z"
    message: 'invalid name: testname. CR name must be: cluster'
    observedGeneration: 1
    reason: ValidationFailed
    status: "False"
    type: Ready
```