### PR TITLE
Update pull secret

### DIFF
--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -121,8 +121,15 @@ type RegistryCert struct {
 }
 
 const (
-	ConditionTypeReady string = "Ready"
-	ConditionTypeApi   string = "APIReconciled"
+	ConditionTypeReady      string = "Ready"
+	ConditionTypeApi        string = "APIReconciled"
+	ConditionTypePullSecret string = "PullSecretReconciled"
+)
+
+const (
+	PullSecretName       string = "pull-secret"
+	BackupPullSecretName string = "backup-pull-secret"
+	ConfigNamespace      string = "openshift-config"
 )
 
 const (

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -199,13 +199,11 @@ func (r *ClusterRelocationReconciler) updateStatus(ctx context.Context, relocati
 }
 
 func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, logger logr.Logger, relocation *rhsysenggithubiov1beta1.ClusterRelocation) error {
-	err := reconcileApi.Cleanup(r.Client, ctx, logger)
-	if err != nil {
+	if err := reconcileApi.Cleanup(r.Client, ctx, logger); err != nil {
 		return err
 	}
 
-	err = reconcilePullSecret.Cleanup(r.Client, r.Scheme, ctx, relocation, logger)
-	if err != nil {
+	if err := reconcilePullSecret.Cleanup(r.Client, r.Scheme, ctx, relocation, logger); err != nil {
 		return err
 	}
 

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -218,6 +218,7 @@ func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, lo
 	// If we modified the original pull secret, we need to restore it
 	backupPullSecret := &corev1.Secret{}
 	if err := r.Client.Get(ctx, types.NamespacedName{Name: rhsysenggithubiov1beta1.BackupPullSecretName, Namespace: rhsysenggithubiov1beta1.ConfigNamespace}, backupPullSecret); err != nil {
+		// if there is no backup, that means we didn't modify the pull-secret. Nothing for us to do
 		if !errors.IsNotFound(err) {
 			return err
 		}

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -144,7 +144,7 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		apimeta.SetStatusCondition(&relocation.Status.Conditions, apiCondition)
 	}
 
-	// Applied a new cluster-wide pull secret
+	// Apply a new cluster-wide pull secret
 	if err := reconcilePullSecret.Reconcile(r.Client, r.Scheme, ctx, relocation, logger); err != nil {
 		pullSecretCondition := metav1.Condition{
 			Status:             metav1.ConditionFalse,

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -222,17 +222,16 @@ func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, lo
 			return err
 		}
 	} else {
-		// copy the backup pull secret into the original, then delete the backup
-		op, err := secrets.CopySecret(ctx, r.Client, relocation, r.Scheme, rhsysenggithubiov1beta1.BackupPullSecretName, rhsysenggithubiov1beta1.ConfigNamespace, rhsysenggithubiov1beta1.PullSecretName, rhsysenggithubiov1beta1.ConfigNamespace)
+		// copy the backup pull secret into the cluster-wide pull secret
+		// the backup should already be owned by the controller
+		// we should not own the cluster-wide pull secret
+		copySettings := secrets.SecretCopySettings{}
+		op, err := secrets.CopySecret(ctx, r.Client, relocation, r.Scheme, rhsysenggithubiov1beta1.BackupPullSecretName, rhsysenggithubiov1beta1.ConfigNamespace, rhsysenggithubiov1beta1.PullSecretName, rhsysenggithubiov1beta1.ConfigNamespace, copySettings)
 		if err != nil {
 			return err
 		}
 		if op != controllerutil.OperationResultNone {
 			logger.Info("Restored original pull secret", "OperationResult", op)
-		}
-		err = r.Client.Delete(ctx, backupPullSecret)
-		if err != nil {
-			return err
 		}
 	}
 	logger.Info("Successfully finalized ClusterRelocation")

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
-	certs "github.com/RHsyseng/cluster-relocation-operator/internal/certs"
+	secrets "github.com/RHsyseng/cluster-relocation-operator/internal/secrets"
 	"github.com/go-logr/logr"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -16,16 +16,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// APIServer requires the certificate to exist in the openshift-config namespace
-const configNamespace = "openshift-config"
-
 func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	var origSecretName string
 	var origSecretNamespace string
 	if relocation.Spec.ApiCertRef.Name == "" {
 		// If they haven't specified an ApiCertRef, we generate a self-signed certificate for them
 		origSecretName = "generated-api-secret"
-		origSecretNamespace = configNamespace
+		origSecretNamespace = rhsysenggithubiov1beta1.ConfigNamespace
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: origSecretName, Namespace: origSecretNamespace}}
 
 		op, err := controllerutil.CreateOrUpdate(ctx, client, secret, func() error {
@@ -35,7 +32,7 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 			// This is done so that we don't generate a new certificate each time Reconcile runs
 			if !ok {
 				logger.Info("generating new TLS cert for API")
-				certData, keyData, err := certs.GenerateTLSKeyPair(relocation.Spec.Domain)
+				certData, keyData, err := secrets.GenerateTLSKeyPair(relocation.Spec.Domain)
 				if err != nil {
 					return err
 				}
@@ -64,15 +61,15 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 
 		// The certificate must be in the openshift-config namespace
 		// so if their certificate is in another namespace, we copy it
-		if origSecretNamespace != configNamespace {
+		if origSecretNamespace != rhsysenggithubiov1beta1.ConfigNamespace {
 			secretName := "copied-api-secret"
 			// Copy the secret into the openshift-config namespace
-			op, err := certs.CopySecret(ctx, client, relocation, scheme, origSecretName, origSecretNamespace, secretName, configNamespace)
+			op, err := secrets.CopySecret(ctx, client, relocation, scheme, origSecretName, origSecretNamespace, secretName, rhsysenggithubiov1beta1.ConfigNamespace)
 			if err != nil {
 				return err
 			}
 			if op != controllerutil.OperationResultNone {
-				logger.Info("User provided cert copied to openshift-config", "OperationResult", op)
+				logger.Info(fmt.Sprintf("User provided cert copied to %s", rhsysenggithubiov1beta1.ConfigNamespace), "OperationResult", op)
 			}
 			origSecretName = secretName
 		}

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -45,8 +45,7 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 			}
 			secret.Type = corev1.SecretTypeTLS
 			// Set the controller as the owner so that the secret is deleted along with the CR
-			err := controllerutil.SetControllerReference(relocation, secret, scheme)
-			return err
+			return controllerutil.SetControllerReference(relocation, secret, scheme)
 		})
 		if err != nil {
 			return err

--- a/internal/pullSecret/reconcile.go
+++ b/internal/pullSecret/reconcile.go
@@ -86,6 +86,8 @@ func Cleanup(client client.Client, scheme *runtime.Scheme, ctx context.Context, 
 		// we delete the backup so that if they ever move back to PullSecretRef=<something>, a fresh backup is taken
 		if err := client.Delete(ctx, backupPullSecret); err != nil {
 			return err
+		} else {
+			logger.Info("Deleted backup pull secret")
 		}
 	}
 	return nil

--- a/internal/pullSecret/reconcile.go
+++ b/internal/pullSecret/reconcile.go
@@ -82,9 +82,7 @@ func Cleanup(client client.Client, scheme *runtime.Scheme, ctx context.Context, 
 			logger.Info("Restored original pull secret", "OperationResult", op)
 		}
 		if err := client.Delete(ctx, backupPullSecret); err != nil {
-			if !errors.IsNotFound(err) {
-				return err
-			}
+			return err
 		}
 	}
 	return nil

--- a/internal/pullSecret/reconcile.go
+++ b/internal/pullSecret/reconcile.go
@@ -81,6 +81,8 @@ func Cleanup(client client.Client, scheme *runtime.Scheme, ctx context.Context, 
 		if op != controllerutil.OperationResultNone {
 			logger.Info("Restored original pull secret", "OperationResult", op)
 		}
+		// when run as part of the finalizer, deleting the backup pull-secret isn't required (it will be deleted automatically)
+		// however, we also run this if the user moves from PullSecretRef=<something> to PullSecretRef=<empty>
 		if err := client.Delete(ctx, backupPullSecret); err != nil {
 			return err
 		}

--- a/internal/pullSecret/reconcile.go
+++ b/internal/pullSecret/reconcile.go
@@ -83,6 +83,7 @@ func Cleanup(client client.Client, scheme *runtime.Scheme, ctx context.Context, 
 		}
 		// when run as part of the finalizer, deleting the backup pull-secret isn't required (it will be deleted automatically)
 		// however, we also run this if the user moves from PullSecretRef=<something> to PullSecretRef=<empty>
+		// we delete the backup so that if they ever move back to PullSecretRef=<something>, a fresh backup is taken
 		if err := client.Delete(ctx, backupPullSecret); err != nil {
 			return err
 		}

--- a/internal/pullSecret/reconcile.go
+++ b/internal/pullSecret/reconcile.go
@@ -1,0 +1,45 @@
+package pullSecret
+
+import (
+	"context"
+
+	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
+	secrets "github.com/RHsyseng/cluster-relocation-operator/internal/secrets"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
+	backupPullSecret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{Name: rhsysenggithubiov1beta1.BackupPullSecretName, Namespace: rhsysenggithubiov1beta1.ConfigNamespace}, backupPullSecret); err != nil {
+		if errors.IsNotFound(err) {
+			// if we haven't yet made a backup of the original pull secret, make one now
+			op, err := secrets.CopySecret(ctx, client, relocation, scheme, rhsysenggithubiov1beta1.PullSecretName, rhsysenggithubiov1beta1.ConfigNamespace, rhsysenggithubiov1beta1.BackupPullSecretName, rhsysenggithubiov1beta1.ConfigNamespace)
+			if err != nil {
+				return err
+			}
+			if op != controllerutil.OperationResultNone {
+				logger.Info("Made a backup of the original pull secret", "OperationResult", op)
+			}
+		} else {
+			return err
+		}
+	}
+	if relocation.Spec.PullSecretRef.Name == "" {
+		// if they don't specify a new pull secret, nothing to do
+		return nil
+	}
+	op, err := secrets.CopySecret(ctx, client, relocation, scheme, relocation.Spec.PullSecretRef.Name, relocation.Spec.PullSecretRef.Namespace, rhsysenggithubiov1beta1.PullSecretName, rhsysenggithubiov1beta1.ConfigNamespace)
+	if err != nil {
+		return err
+	}
+	if op != controllerutil.OperationResultNone {
+		logger.Info("Updated pull secret", "OperationResult", op)
+	}
+	return nil
+}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -50,10 +50,6 @@ func GenerateTLSKeyPair(domain string) ([]byte, []byte, error) {
 	return certificatePEM, privateKeyPEM, nil
 }
 
-// We allow the user to specify a certificate for the API and Ingress in any namespace
-// However, APIServer expects the certificate to exist in openshift-config
-// and Ingress expects 2 copies of the certificate: one in openshift-config and another in openshift-ingress.
-// This function copies their certificate into the required locations
 func CopySecret(ctx context.Context, client client.Client, relocation *rhsysenggithubiov1beta1.ClusterRelocation, scheme *runtime.Scheme,
 	origSecretName string, origSecretNamespace string, destSecretName string, destSecretNamespace string) (controllerutil.OperationResult, error) {
 	origSecret := &corev1.Secret{}
@@ -61,7 +57,7 @@ func CopySecret(ctx context.Context, client client.Client, relocation *rhsysengg
 		return controllerutil.OperationResultNone, err
 	}
 
-	// We set an owner reference on the user provided certificate
+	// We set an owner reference on the user provided secret
 	// so that if it ever changes, it will trigger a Reconcile (and the changes will be copied).
 	// We don't use SetControllerReference because an object can only have 1 controller owner
 	// and the secret may be owned by another controller (cert-manager for example)

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -57,6 +57,7 @@ func GenerateTLSKeyPair(domain string) ([]byte, []byte, error) {
 	return certificatePEM, privateKeyPEM, nil
 }
 
+// copies a secret from one location to another
 func CopySecret(ctx context.Context, client client.Client, relocation *rhsysenggithubiov1beta1.ClusterRelocation, scheme *runtime.Scheme,
 	origSecretName string, origSecretNamespace string, destSecretName string, destSecretNamespace string, settings SecretCopySettings) (controllerutil.OperationResult, error) {
 	origSecret := &corev1.Secret{}

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -85,13 +85,15 @@ func CopySecret(ctx context.Context, client client.Client, relocation *rhsysengg
 		secret.Data = origSecret.Data
 		secret.Type = origSecret.Type
 		if settings.OwnDestination {
-			var err error
 			if settings.DestinationOwnedByController {
-				err = controllerutil.SetControllerReference(relocation, secret, scheme)
+				if err := controllerutil.SetControllerReference(relocation, secret, scheme); err != nil {
+					return err
+				}
 			} else {
-				err = controllerutil.SetOwnerReference(relocation, secret, scheme)
+				if err := controllerutil.SetOwnerReference(relocation, secret, scheme); err != nil {
+					return err
+				}
 			}
-			return err
 		}
 		return nil
 	})

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -74,12 +74,8 @@ func CopySecret(ctx context.Context, client client.Client, relocation *rhsysengg
 
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: destSecretName, Namespace: destSecretNamespace}}
 	op, err := controllerutil.CreateOrUpdate(ctx, client, secret, func() error {
-		secret.Data = map[string][]byte{
-			corev1.TLSCertKey:       origSecret.Data[corev1.TLSCertKey],
-			corev1.TLSPrivateKeyKey: origSecret.Data[corev1.TLSPrivateKeyKey],
-		}
-
-		secret.Type = corev1.SecretTypeTLS
+		secret.Data = origSecret.Data
+		secret.Type = origSecret.Type
 		// Set the controller as the owner of the copied secret so that the secret is deleted along with the CR
 		err := controllerutil.SetControllerReference(relocation, secret, scheme)
 		return err


### PR DESCRIPTION
Fixes https://github.com/RHsyseng/cluster-relocation-operator/issues/7

Here is the workflow:

- Create a backup of the original pull-secret. The finalizer (which runs when the CR is deleted) will restore the pull-secret from this backup if it exists
- Copy their secret to openshift-config/pull-secret
- The controller sets ownership of their secret, so it can watch it. If they ever update their pull secret, the reconcile loop will be triggered and the changes will be copied into the cluster-wide pull-secret

I modified the CopySecret function a bit in order to give it more flexibility into which secrets get ownership attached to them