### PR TITLE
Use ImageDigestMirrorSet for OCP 4.13+

### DIFF
--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -17,7 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,8 +36,8 @@ type ClusterRelocationSpec struct {
 	// Domain defines the new base domain for the cluster.
 	Domain string `json:"domain"`
 
-	// ImageDigestSources will be converted into ImageContentSourcePolicys on the cluster.
-	ImageDigestSources []operatorv1alpha1.RepositoryDigestMirrors `json:"imageDigestSources,omitempty"`
+	// ImageDigestMirrors is used to configured a mirror registry on the cluster.
+	ImageDigestMirrors []configv1.ImageDigestMirrors `json:"imageDigestMirrors,omitempty"`
 
 	// IngressCertRef is a reference to a TLS secret that will be used for the Ingress Controller.
 	// If it is omitted, a self-signed certificate will be generated.

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -22,8 +22,8 @@ limitations under the License.
 package v1beta1
 
 import (
-	"github.com/openshift/api/operator/v1alpha1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -110,9 +110,9 @@ func (in *ClusterRelocationSpec) DeepCopyInto(out *ClusterRelocationSpec) {
 		*out = make([]CatalogSource, len(*in))
 		copy(*out, *in)
 	}
-	if in.ImageDigestSources != nil {
-		in, out := &in.ImageDigestSources, &out.ImageDigestSources
-		*out = make([]v1alpha1.RepositoryDigestMirrors, len(*in))
+	if in.ImageDigestMirrors != nil {
+		in, out := &in.ImageDigestMirrors, &out.ImageDigestMirrors
+		*out = make([]v1.ImageDigestMirrors, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
@@ -142,7 +142,7 @@ func (in *ClusterRelocationStatus) DeepCopyInto(out *ClusterRelocationStatus) {
 	*out = *in
 	if in.Conditions != nil {
 		in, out := &in.Conditions, &out.Conditions
-		*out = make([]v1.Condition, len(*in))
+		*out = make([]metav1.Condition, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/config/crd/bases/rhsyseng.github.io_clusterrelocations.yaml
+++ b/config/crd/bases/rhsyseng.github.io_clusterrelocations.yaml
@@ -70,31 +70,61 @@ spec:
               domain:
                 description: Domain defines the new base domain for the cluster.
                 type: string
-              imageDigestSources:
-                description: ImageDigestSources will be converted into ImageContentSourcePolicys
+              imageDigestMirrors:
+                description: ImageDigestMirrors is used to configured a mirror registry
                   on the cluster.
                 items:
-                  description: 'RepositoryDigestMirrors holds cluster-wide information
-                    about how to handle mirros in the registries config. Note: the
-                    mirrors only work when pulling the images that are referenced
-                    by their digests.'
+                  description: ImageDigestMirrors holds cluster-wide information about
+                    how to handle mirrors in the registries config.
                   properties:
+                    mirrorSourcePolicy:
+                      description: mirrorSourcePolicy defines the fallback policy
+                        if fails to pull image from the mirrors. If unset, the image
+                        will continue to be pulled from the the repository in the
+                        pull spec. sourcePolicy is valid configuration only when one
+                        or more mirrors are in the mirror list.
+                      enum:
+                      - NeverContactSource
+                      - AllowContactingSource
+                      type: string
                     mirrors:
-                      description: mirrors is one or more repositories that may also
-                        contain the same images. The order of mirrors in this list
-                        is treated as the user's desired priority, while source is
-                        by default considered lower priority than all mirrors. Other
+                      description: 'mirrors is zero or more locations that may also
+                        contain the same images. No mirror will be configured if not
+                        specified. Images can be pulled from these mirrors only if
+                        they are referenced by their digests. The mirrored location
+                        is obtained by replacing the part of the input reference that
+                        matches source by the mirrors entry, e.g. for registry.redhat.io/product/repo
+                        reference, a (source, mirror) pair *.redhat.io, mirror.local/redhat
+                        causes a mirror.local/redhat/product/repo repository to be
+                        used. The order of mirrors in this list is treated as the
+                        user''s desired priority, while source is by default considered
+                        lower priority than all mirrors. If no mirror is specified
+                        or all image pulls from the mirror list fail, the image will
+                        continue to be pulled from the repository in the pull spec
+                        unless explicitly prohibited by "mirrorSourcePolicy" Other
                         cluster configuration, including (but not limited to) other
-                        repositoryDigestMirrors objects, may impact the exact order
-                        mirrors are contacted in, or some mirrors may be contacted
-                        in parallel, so this should be considered a preference rather
-                        than a guarantee of ordering.
+                        imageDigestMirrors objects, may impact the exact order mirrors
+                        are contacted in, or some mirrors may be contacted in parallel,
+                        so this should be considered a preference rather than a guarantee
+                        of ordering. "mirrors" uses one of the following formats:
+                        host[:port] host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo
+                        for more information about the format, see the document about
+                        the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
                       items:
+                        pattern: ^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
                         type: string
                       type: array
+                      x-kubernetes-list-type: set
                     source:
-                      description: source is the repository that users refer to, e.g.
-                        in image pull specifications.
+                      description: 'source matches the repository that users refer
+                        to, e.g. in image pull specifications. Setting source to a
+                        registry hostname e.g. docker.io. quay.io, or registry.redhat.io,
+                        will match the image pull specification of corressponding
+                        registry. "source" uses one of the following formats: host[:port]
+                        host[:port]/namespace[/namespace…] host[:port]/namespace[/namespace…]/repo
+                        [*.]host for more information about the format, see the document
+                        about the location field: https://github.com/containers/image/blob/main/docs/containers-registries.conf.5.md#choosing-a-registry-toml-table'
+                      pattern: ^\*(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+$|^((?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))+)?(?::[0-9]+)?)(?:(?:/[a-z0-9]+(?:(?:(?:[._]|__|[-]*)[a-z0-9]+)+)?)+)?$
                       type: string
                   required:
                   - source

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v0.0.0-20230221095031-69130006bb23
 	github.com/openshift/machine-config-operator v0.0.1-0.20230526005055-5843b7a4b27f
+	golang.org/x/mod v0.10.0
 	k8s.io/apimachinery v0.26.5
 	k8s.io/client-go v0.26.5
 	sigs.k8s.io/controller-runtime v0.14.6

--- a/go.sum
+++ b/go.sum
@@ -190,6 +190,7 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.10.0 h1:lFO9qtOdlre5W1jxS3r/4szv2/6iXxScdzjoBMXNhYk=
+golang.org/x/mod v0.10.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/internal/mirror/reconcile.go
+++ b/internal/mirror/reconcile.go
@@ -31,6 +31,10 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 	if semver.Compare(fmt.Sprintf("v%s", clusterVersion.Status.Desired.Version), "v4.13.0") == -1 {
 		return createICSP(client, scheme, ctx, relocation, logger)
 	} else {
+		// In case we are upgrading from 4.12 to 4.13+, remove any old ImageContentSourcePolicy
+		if err := cleanupICSP(client, ctx, logger); err != nil {
+			return err
+		}
 		return createIDMS(client, scheme, ctx, relocation, logger)
 	}
 }

--- a/internal/mirror/reconcile.go
+++ b/internal/mirror/reconcile.go
@@ -2,27 +2,70 @@ package mirror
 
 import (
 	"context"
+	"fmt"
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
 	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	"golang.org/x/mod/semver"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const IcspName = "mirror-ocp"
+const ImageSetName = "mirror-ocp"
 
 func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
-	if len(relocation.Spec.ImageDigestSources) == 0 {
+	if len(relocation.Spec.ImageDigestMirrors) == 0 {
 		return Cleanup(client, ctx, logger)
 	}
 
-	icsp := &operatorv1alpha1.ImageContentSourcePolicy{ObjectMeta: metav1.ObjectMeta{Name: IcspName}}
+	clusterVersion := &configv1.ClusterVersion{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+		return err
+	}
+	if semver.Compare(fmt.Sprintf("v%s", clusterVersion.Status.Desired.Version), "v4.13.0") == -1 {
+		return createICSP(client, scheme, ctx, relocation, logger)
+	} else {
+		return createIDMS(client, scheme, ctx, relocation, logger)
+	}
+}
+
+func Cleanup(client client.Client, ctx context.Context, logger logr.Logger) error {
+	// if they move from relocation.Spec.ImageDigestMirrors=<something> to relocation.Spec.ImageDigestMirrors=<empty>, we need to delete the ICSP
+	clusterVersion := &configv1.ClusterVersion{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "version"}, clusterVersion); err != nil {
+		return err
+	}
+	if semver.Compare(fmt.Sprintf("v%s", clusterVersion.Status.Desired.Version), "v4.13.0") == -1 {
+		return cleanupICSP(client, ctx, logger)
+	} else {
+		return cleanupIDMS(client, ctx, logger)
+	}
+}
+
+// ImageContentSourcePolicy is deprecated since OCP 4.13
+// This function converts the values in Spec.RepositoryDigestMirrors into an ImageContentSourcePolicy
+// Used for OCP < 4.13
+func createICSP(client client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
+	icsp := &operatorv1alpha1.ImageContentSourcePolicy{ObjectMeta: metav1.ObjectMeta{Name: ImageSetName}}
 	op, err := controllerutil.CreateOrUpdate(ctx, client, icsp, func() error {
-		icsp.Spec.RepositoryDigestMirrors = relocation.Spec.ImageDigestSources
+		icsp.Spec.RepositoryDigestMirrors = []operatorv1alpha1.RepositoryDigestMirrors{}
+		for _, v := range relocation.Spec.ImageDigestMirrors {
+			mirrors := []string{}
+			for _, v := range v.Mirrors {
+				mirrors = append(mirrors, string(v))
+			}
+			item := operatorv1alpha1.RepositoryDigestMirrors{
+				Source:  v.Source,
+				Mirrors: mirrors,
+			}
+			icsp.Spec.RepositoryDigestMirrors = append(icsp.Spec.RepositoryDigestMirrors, item)
+		}
 		// Set the controller as the owner so that the ICSP is deleted along with the CR
 		return controllerutil.SetControllerReference(relocation, icsp, scheme)
 	})
@@ -30,20 +73,48 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 		return err
 	}
 	if op != controllerutil.OperationResultNone {
-		logger.Info("Updated Image Content Sources", "ImageContentSourcePolicy", IcspName, "OperationResult", op)
+		logger.Info("Updated Image Content Sources", "ImageContentSourcePolicy", ImageSetName, "OperationResult", op)
 	}
 	return nil
 }
 
-func Cleanup(client client.Client, ctx context.Context, logger logr.Logger) error {
-	// if they move from relocation.Spec.ImageDigestSources=<something> to relocation.Spec.ImageDigestSources=<empty>, we need to delete the ICSP
-	icsp := &operatorv1alpha1.ImageContentSourcePolicy{ObjectMeta: metav1.ObjectMeta{Name: IcspName}}
+func createIDMS(client client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
+	idms := &configv1.ImageDigestMirrorSet{ObjectMeta: metav1.ObjectMeta{Name: ImageSetName}}
+	op, err := controllerutil.CreateOrUpdate(ctx, client, idms, func() error {
+		idms.Spec.ImageDigestMirrors = relocation.Spec.ImageDigestMirrors
+
+		// Set the controller as the owner so that the IDMS is deleted along with the CR
+		return controllerutil.SetControllerReference(relocation, idms, scheme)
+	})
+	if err != nil {
+		return err
+	}
+	if op != controllerutil.OperationResultNone {
+		logger.Info("Updated Image Content Sources", "ImageDigestMirrorSet", ImageSetName, "OperationResult", op)
+	}
+	return nil
+}
+
+func cleanupICSP(client client.Client, ctx context.Context, logger logr.Logger) error {
+	icsp := &operatorv1alpha1.ImageContentSourcePolicy{ObjectMeta: metav1.ObjectMeta{Name: ImageSetName}}
 	if err := client.Delete(ctx, icsp); err != nil {
 		if !errors.IsNotFound(err) {
 			return err
 		}
 	} else {
-		logger.Info("ICSP deleted", "ImageContentSourcePolicy", IcspName)
+		logger.Info("ICSP deleted", "ImageContentSourcePolicy", ImageSetName)
+	}
+	return nil
+}
+
+func cleanupIDMS(client client.Client, ctx context.Context, logger logr.Logger) error {
+	idms := &configv1.ImageDigestMirrorSet{ObjectMeta: metav1.ObjectMeta{Name: ImageSetName}}
+	if err := client.Delete(ctx, idms); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		logger.Info("IDMS deleted", "ImageDigestMirrorSet", ImageSetName)
 	}
 	return nil
 }

--- a/internal/mirror/reconcile.go
+++ b/internal/mirror/reconcile.go
@@ -57,8 +57,8 @@ func createICSP(client client.Client, scheme *runtime.Scheme, ctx context.Contex
 		icsp.Spec.RepositoryDigestMirrors = []operatorv1alpha1.RepositoryDigestMirrors{}
 		for _, v := range relocation.Spec.ImageDigestMirrors {
 			mirrors := []string{}
-			for _, v := range v.Mirrors {
-				mirrors = append(mirrors, string(v))
+			for _, w := range v.Mirrors {
+				mirrors = append(mirrors, string(w))
 			}
 			item := operatorv1alpha1.RepositoryDigestMirrors{
 				Source:  v.Source,


### PR DESCRIPTION
`ImageContentSourcePolicy` is deprecated since OCP 4.13[1].

This change makes it so that the operator will create the new `ImageDigestMirrorSet` for OCP 4.13+, while still supporting `ImageContentSourcePolicy` on OCP less than 4.13

[1]https://docs.openshift.com/container-platform/4.13/release_notes/ocp-4-13-release-notes.html#ocp-4-13-nodes-mirror