### PR TITLE
Re-generate self-signed certificate if domain changes

### DIFF
--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -26,22 +26,30 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: origSecretName, Namespace: origSecretNamespace}}
 
 		op, err := controllerutil.CreateOrUpdate(ctx, client, secret, func() error {
-			_, ok := secret.Data[corev1.TLSPrivateKeyKey]
+			_, ok := secret.Data[corev1.TLSCertKey]
 			// Check if the secret already has a key set
 			// If there is no key set, generate one
 			// This is done so that we don't generate a new certificate each time Reconcile runs
 			if !ok {
-				logger.Info("generating new TLS cert for API")
-				certData, keyData, err := secrets.GenerateTLSKeyPair(relocation.Spec.Domain)
+				var err error
+				secret.Data, err = generateNewCert(relocation, logger)
 				if err != nil {
 					return err
 				}
-				secret.Data = map[string][]byte{
-					corev1.TLSCertKey:       certData,
-					corev1.TLSPrivateKeyKey: keyData,
-				}
 			} else {
 				logger.Info("TLS cert already exists for API")
+				commonName, err := secrets.GetCertCommonName(secret.Data[corev1.TLSCertKey])
+				if err != nil {
+					return err
+				}
+				if commonName != fmt.Sprintf("api.%s", relocation.Spec.Domain) {
+					logger.Info("Domain name has changed, generating new TLS certificate for API")
+					var err error
+					secret.Data, err = generateNewCert(relocation, logger)
+					if err != nil {
+						return err
+					}
+				}
 			}
 			secret.Type = corev1.SecretTypeTLS
 			// Set the controller as the owner so that the secret is deleted along with the CR
@@ -117,4 +125,16 @@ func Cleanup(client client.Client, ctx context.Context, logger logr.Logger) erro
 		logger.Info("APIServer reverted to original state", "OperationResult", op)
 	}
 	return nil
+}
+
+func generateNewCert(relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) (map[string][]byte, error) {
+	logger.Info("generating new TLS cert for API")
+	certData, keyData, err := secrets.GenerateTLSKeyPair(relocation.Spec.Domain)
+	if err != nil {
+		return nil, err
+	}
+	return map[string][]byte{
+		corev1.TLSCertKey:       certData,
+		corev1.TLSPrivateKeyKey: keyData,
+	}, nil
 }

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -42,34 +42,37 @@ func GetCertCommonName(TLSCertKey []byte) (string, error) {
 	return cert.Subject.CommonName, nil
 }
 
-func GenerateTLSKeyPair(domain string) ([]byte, []byte, error) {
+func GenerateTLSKeyPair(domain string, prefix string) (map[string][]byte, error) {
 	// Generate a private key
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Create a self-signed certificate template
 	certificateTemplate := x509.Certificate{
 		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: fmt.Sprintf("api.%s", domain)},
+		Subject:               pkix.Name{CommonName: fmt.Sprintf("%s.%s", prefix, domain)},
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(3650 * 24 * time.Hour), // Valid for 10 years
 		BasicConstraintsValid: true,
-		DNSNames:              []string{fmt.Sprintf("api.%s", domain)},
+		DNSNames:              []string{fmt.Sprintf("%s.%s", prefix, domain)},
 	}
 
 	// Create a self-signed certificate using the private key and certificate template
 	derBytes, err := x509.CreateCertificate(rand.Reader, &certificateTemplate, &certificateTemplate, &privateKey.PublicKey, privateKey)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Create PEM blocks for the certificate and private key
 	certificatePEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
 	privateKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(privateKey)})
 
-	return certificatePEM, privateKeyPEM, nil
+	return map[string][]byte{
+		corev1.TLSCertKey:       certificatePEM,
+		corev1.TLSPrivateKeyKey: privateKeyPEM,
+	}, nil
 }
 
 // copies a secret from one location to another

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -27,6 +27,21 @@ type SecretCopySettings struct {
 	DestinationOwnedByController bool
 }
 
+func GetCertCommonName(TLSCertKey []byte) (string, error) {
+	block, _ := pem.Decode(TLSCertKey)
+	if block == nil {
+		return "", fmt.Errorf("failed to decode certificate")
+	}
+
+	// Parse the certificate
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return "", err
+	}
+
+	return cert.Subject.CommonName, nil
+}
+
 func GenerateTLSKeyPair(domain string) ([]byte, []byte, error) {
 	// Generate a private key
 	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)


### PR DESCRIPTION
If someone was to modify `spec.domain`, then we need to re-generated the API certificate so that it matches the new domain name