### PR TITLE
Reconcile Catalog Sources

### DIFF
--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -117,6 +117,7 @@ const (
 	ConditionTypeRegistryCert string = "RegistryCertReconciled"
 	ConditionTypeMirror       string = "MirrorReconciled"
 	ConditionTypeDns          string = "DNSReconciled"
+	ConditionTypeCatalog      string = "CatalogReconciled"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/onsi/gomega v1.27.7
 	github.com/openshift/api v0.0.0-20230221095031-69130006bb23
 	github.com/openshift/machine-config-operator v0.0.1-0.20230526005055-5843b7a4b27f
+	github.com/operator-framework/api v0.17.6
 	golang.org/x/mod v0.10.0
 	k8s.io/apimachinery v0.26.5
 	k8s.io/client-go v0.26.5
@@ -14,8 +15,10 @@ require (
 )
 
 require (
+	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/go-task/slim-sprig v0.0.0-20230315185526-52ccab3ef572 // indirect
 	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
+	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/tools v0.9.1 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLj
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -130,6 +132,8 @@ github.com/openshift/api v0.0.0-20230221095031-69130006bb23 h1:6hkSewbomhxN9+WQh
 github.com/openshift/api v0.0.0-20230221095031-69130006bb23/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
 github.com/openshift/machine-config-operator v0.0.1-0.20230526005055-5843b7a4b27f h1:1rGP3q4vb8IIJlw7MIkcaO1T4UsyvmsUb7+q9IOBrRU=
 github.com/openshift/machine-config-operator v0.0.1-0.20230526005055-5843b7a4b27f/go.mod h1:PTjUlYquPE9ZorTzuwsbr4kPms67DF8Y79jqnQcYi4Y=
+github.com/operator-framework/api v0.17.6 h1:E6+vlvYUKafvoXYtCuHlDZrXX4vl8AT+r93OxNlzjpU=
+github.com/operator-framework/api v0.17.6/go.mod h1:l/cuwtPxkVUY7fzYgdust2m9tlmb8I4pOvbsUufRb24=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -146,6 +150,8 @@ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+Pymzi
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
+github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace h1:9PNP1jnUjRhfmGMlkXHjYPishpcw4jpSt/V/xYY3FMA=
 github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
@@ -227,6 +233,7 @@ golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/catalog/reconcile.go
+++ b/internal/catalog/reconcile.go
@@ -1,0 +1,66 @@
+package catalog
+
+import (
+	"context"
+
+	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
+	"github.com/go-logr/logr"
+	operatorhubv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const marketplaceNamespace = "openshift-marketplace"
+
+func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
+	if err := Cleanup(c, ctx, relocation, logger); err != nil {
+		return err
+	}
+
+	for _, v := range relocation.Spec.CatalogSources {
+		catalogSource := &operatorhubv1alpha1.CatalogSource{ObjectMeta: metav1.ObjectMeta{Name: v.Name, Namespace: marketplaceNamespace}}
+		op, err := controllerutil.CreateOrUpdate(ctx, c, catalogSource, func() error {
+			catalogSource.Spec.Image = v.Image
+			catalogSource.Spec.SourceType = operatorhubv1alpha1.SourceTypeGrpc
+			// Set the controller as the owner so that the CatalogSource is deleted along with the CR
+			return controllerutil.SetControllerReference(relocation, catalogSource, scheme)
+		})
+		if err != nil {
+			return err
+		}
+		if op != controllerutil.OperationResultNone {
+			logger.Info("Updated Catalog Source", "CatalogSource", v.Name, "OperationResult", op)
+		}
+	}
+	return nil
+}
+
+func Cleanup(c client.Client, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
+	// if they remove something from relocation.Spec.CatalogSources, we need to clean it up
+	catalogSources := &operatorhubv1alpha1.CatalogSourceList{}
+	if err := c.List(ctx, catalogSources, client.InNamespace(marketplaceNamespace)); err != nil {
+		return err
+	}
+	for _, v := range catalogSources.Items { // loop through all existing CatalogSources
+		if len(v.ObjectMeta.OwnerReferences) > 0 &&
+			v.ObjectMeta.OwnerReferences[0].APIVersion == relocation.APIVersion &&
+			v.ObjectMeta.OwnerReferences[0].Kind == relocation.Kind { // check if we own this CatalogSource
+			var existsInSpec bool
+			for _, w := range relocation.Spec.CatalogSources { // check if the current Spec wants this CatalogSource
+				if v.Name == w.Name {
+					existsInSpec = true
+				}
+			}
+			if !existsInSpec {
+				// if we own this CatalogSource, but it's not in the Spec, then it is old and needs to be removed
+				if err := c.Delete(ctx, &v); err != nil {
+					return err
+				}
+				logger.Info("Deleted old Catalog Source", "CatalogSource", v.Name)
+			}
+		}
+	}
+	return nil
+}

--- a/internal/dns/reconcile.go
+++ b/internal/dns/reconcile.go
@@ -33,9 +33,9 @@ type MachineConfigData struct {
 	Storage  MachineConfigStorageData `json:"storage"`
 }
 
-func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
+func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	nodes := &corev1.NodeList{}
-	if err := client.List(ctx, nodes); err != nil {
+	if err := c.List(ctx, nodes); err != nil {
 		return err
 	}
 	if len(nodes.Items) > 1 {
@@ -50,7 +50,7 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 	}
 
 	machineConfig := &machineconfigurationv1.MachineConfig{ObjectMeta: metav1.ObjectMeta{Name: "relocation-dns-master"}}
-	op, err := controllerutil.CreateOrUpdate(ctx, client, machineConfig, func() error {
+	op, err := controllerutil.CreateOrUpdate(ctx, c, machineConfig, func() error {
 		snoDnsContents := fmt.Sprintf("address=/apps.%s/%s\n"+
 			"address=/api-int.%s/%s\n"+
 			"address=/api.%s/%s\n",

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -76,10 +76,10 @@ func GenerateTLSKeyPair(domain string, prefix string) (map[string][]byte, error)
 }
 
 // copies a secret from one location to another
-func CopySecret(ctx context.Context, client client.Client, relocation *rhsysenggithubiov1beta1.ClusterRelocation, scheme *runtime.Scheme,
+func CopySecret(ctx context.Context, c client.Client, relocation *rhsysenggithubiov1beta1.ClusterRelocation, scheme *runtime.Scheme,
 	origSecretName string, origSecretNamespace string, destSecretName string, destSecretNamespace string, settings SecretCopySettings) (controllerutil.OperationResult, error) {
 	origSecret := &corev1.Secret{}
-	if err := client.Get(ctx, types.NamespacedName{Name: origSecretName, Namespace: origSecretNamespace}, origSecret); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: origSecretName, Namespace: origSecretNamespace}, origSecret); err != nil {
 		return controllerutil.OperationResultNone, err
 	}
 
@@ -93,13 +93,13 @@ func CopySecret(ctx context.Context, client client.Client, relocation *rhsysengg
 				return controllerutil.OperationResultNone, err
 			}
 		}
-		if err := client.Update(ctx, origSecret); err != nil {
+		if err := c.Update(ctx, origSecret); err != nil {
 			return controllerutil.OperationResultNone, err
 		}
 	}
 
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: destSecretName, Namespace: destSecretNamespace}}
-	op, err := controllerutil.CreateOrUpdate(ctx, client, secret, func() error {
+	op, err := controllerutil.CreateOrUpdate(ctx, c, secret, func() error {
 		secret.Data = origSecret.Data
 		secret.Type = origSecret.Type
 		if settings.OwnDestination {


### PR DESCRIPTION
Fixes https://github.com/RHsyseng/cluster-relocation-operator/issues/11

Besides doing the Catalog Source work, I also made 3 other changes:

- renamed the variable "client" to "c". Because the package is also named "client", I wasn't able to call a function from the "client" package, since it thought I was referring to the "client" variable
- I grouped all the scheme installations into a `installSchemes` function
- Fixed it so that the controller will watch dependant resources for changes (MachineConfigs it created for example). This was a little more complex than I realized, since ImageDigestMirrorSet only exists on OCP 4.13+, the Watch for that resource needs to be added a little differently.

The cleanup function is a little more complex than the others, since it needs to handle cases where they are modifying the list of Catalog Sources and potentially removing some, but not all