### PR TITLE
update ingress apps

### DIFF
--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -112,6 +112,7 @@ type RegistryCert struct {
 const (
 	ConditionTypeReady        string = "Ready"
 	ConditionTypeApi          string = "APIReconciled"
+	ConditionTypeIngress      string = "IngressReconciled"
 	ConditionTypePullSecret   string = "PullSecretReconciled"
 	ConditionTypeSsh          string = "SSHKeyReconciled"
 	ConditionTypeRegistryCert string = "RegistryCertReconciled"

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -24,11 +24,11 @@ import (
 	reconcileApi "github.com/RHsyseng/cluster-relocation-operator/internal/api"
 	reconcileCatalog "github.com/RHsyseng/cluster-relocation-operator/internal/catalog"
 	reconcileDns "github.com/RHsyseng/cluster-relocation-operator/internal/dns"
+	reconcileIngress "github.com/RHsyseng/cluster-relocation-operator/internal/ingress"
 	reconcileMirror "github.com/RHsyseng/cluster-relocation-operator/internal/mirror"
 	reconcilePullSecret "github.com/RHsyseng/cluster-relocation-operator/internal/pullSecret"
 	registryCert "github.com/RHsyseng/cluster-relocation-operator/internal/registryCert"
 	reconcileSsh "github.com/RHsyseng/cluster-relocation-operator/internal/ssh"
-	reconcileIngress "github.com/RHsyseng/cluster-relocation-operator/internal/ingress"
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
@@ -292,8 +292,9 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			ObservedGeneration: relocation.GetGeneration(),
 		}
 		apimeta.SetStatusCondition(&relocation.Status.Conditions, dnsCondition)
-	err := reconcileIngress.Reconcile(r.Client, r.Scheme, ctx, relocation, logger)
-	if err != nil {
+	}
+
+	if err := reconcileIngress.Reconcile(r.Client, r.Scheme, ctx, relocation, logger); err != nil {
 		fmt.Printf("Error while patch ingress controller")
 		ingressCondition := metav1.Condition{
 			Status:             metav1.ConditionFalse,

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -357,6 +357,10 @@ func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, lo
 		return err
 	}
 
+	if err := reconcileIngress.Cleanup(r.Client, ctx, logger); err != nil {
+		return err
+	}
+
 	if err := reconcilePullSecret.Cleanup(r.Client, r.Scheme, ctx, relocation, logger); err != nil {
 		return err
 	}

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
 	machineconfigurationv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	operatorhubv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -364,6 +365,10 @@ func (r *ClusterRelocationReconciler) installSchemes() error {
 		return err
 	}
 
+	if err := operatorv1.Install(r.Scheme); err != nil { // Add config.openshift.io/v1 to the scheme
+		return err
+	}
+
 	if err := machineconfigurationv1.Install(r.Scheme); err != nil { // Add machineconfiguration.openshift.io/v1 to the scheme
 		return err
 	}
@@ -375,6 +380,7 @@ func (r *ClusterRelocationReconciler) installSchemes() error {
 	if err := operatorhubv1alpha1.AddToScheme(r.Scheme); err != nil { // Add operators.coreos.com/v1alpha1 to the scheme
 		return err
 	}
+
 	return nil
 }
 

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -91,6 +91,17 @@ func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, rel
 				logger.Info(fmt.Sprintf("User provided cert copied to %s", rhsysenggithubiov1beta1.ConfigNamespace), "OperationResult", op)
 			}
 			origSecretName = secretName
+
+			// Copy cert secret to openshift-ingress namespace for ingress alias update
+
+			destSecreteNamespace := "openshift-ingress"
+			op, err = secrets.CopySecret(ctx, c, relocation, scheme, origSecretName, origSecretNamespace, secretName, destSecreteNamespace, copySettings)
+			if err != nil {
+				return err
+			}
+			if op != controllerutil.OperationResultNone {
+				logger.Info(fmt.Sprintf("User provided cert copied to %s", rhsysenggithubiov1beta1.ConfigNamespace), "OperationResult", op)
+			}
 		}
 	}
 	// Define the IngressController's namespace and name

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -2,12 +2,14 @@ package ingress
 
 import (
 	"context"
+	"fmt"
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
+	secrets "github.com/RHsyseng/cluster-relocation-operator/internal/secrets"
 	"github.com/go-logr/logr"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -15,6 +17,81 @@ import (
 
 func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 
+	// Configure certificates with the new domain name for the ingress
+	var origSecretName string
+	var origSecretNamespace string
+	if relocation.Spec.IngressCertRef.Name == "" {
+		// If they haven't specified an IngressCertRef, we generate a self-signed certificate for them
+		origSecretName = "generated-ingress-secret"
+		origSecretNamespace = rhsysenggithubiov1beta1.ConfigNamespace
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: origSecretName, Namespace: origSecretNamespace}}
+
+		op, err := controllerutil.CreateOrUpdate(ctx, client, secret, func() error {
+			_, ok := secret.Data[corev1.TLSCertKey]
+			// Check if the secret already has a key set
+			// If there is no key set, generate one
+			// This is done so that we don't generate a new certificate each time Reconcile runs
+			if !ok {
+				logger.Info("generating new TLS cert for Ingresses")
+				var err error
+				secret.Data, err = secrets.GenerateTLSKeyPair(relocation.Spec.Domain, "*.apps")
+				if err != nil {
+					return err
+				}
+			} else {
+				logger.Info("TLS cert already exists for Ingresses")
+				commonName, err := secrets.GetCertCommonName(secret.Data[corev1.TLSCertKey])
+				if err != nil {
+					return err
+				}
+				if commonName != fmt.Sprintf("*.apps.%s", relocation.Spec.Domain) {
+					logger.Info("Domain name has changed, generating new TLS certificate for Ingresses")
+					var err error
+					secret.Data, err = secrets.GenerateTLSKeyPair(relocation.Spec.Domain, "*.apps")
+					if err != nil {
+						return err
+					}
+				}
+			}
+			secret.Type = corev1.SecretTypeTLS
+			// Set the controller as the owner so that the secret is deleted along with the CR
+			return controllerutil.SetControllerReference(relocation, secret, scheme)
+		})
+		if err != nil {
+			return err
+		}
+		if op != controllerutil.OperationResultNone {
+			logger.Info("Self-signed TLS cert modified", "OperationResult", op)
+		}
+	} else {
+		origSecretName = relocation.Spec.IngressCertRef.Name
+		origSecretNamespace = relocation.Spec.IngressCertRef.Namespace
+		logger.Info("Using user provided Ingress certificate", "namespace", origSecretNamespace, "name", origSecretName)
+
+		// The certificate must be in the openshift-config namespace
+		// so if their certificate is in another namespace, we copy it
+		if origSecretNamespace != rhsysenggithubiov1beta1.ConfigNamespace {
+			secretName := "copied-ingress-secret"
+			// Copy the secret into the openshift-config namespace
+			// the original may be owned by another controller (cert-manager for example)
+			// we add non-controller ownership to this secret, in order to watch it.
+			// our controller should own the destination secret
+			copySettings := secrets.SecretCopySettings{
+				OwnOriginal:                  true,
+				OriginalOwnedByController:    false,
+				OwnDestination:               true,
+				DestinationOwnedByController: true,
+			}
+			op, err := secrets.CopySecret(ctx, client, relocation, scheme, origSecretName, origSecretNamespace, secretName, rhsysenggithubiov1beta1.ConfigNamespace, copySettings)
+			if err != nil {
+				return err
+			}
+			if op != controllerutil.OperationResultNone {
+				logger.Info(fmt.Sprintf("User provided cert copied to %s", rhsysenggithubiov1beta1.ConfigNamespace), "OperationResult", op)
+			}
+			origSecretName = secretName
+		}
+	}
 	// Define the IngressController's namespace and name
 	namespace := "openshift-ingress-operator"
 	name := "default"
@@ -27,7 +104,7 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 	}
 
 	ingress := &operatorv1.IngressController{
-		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 		Spec:       operatorv1.IngressControllerSpec{},
 		Status:     operatorv1.IngressControllerStatus{},
 	}

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -95,13 +95,6 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 	// Define the IngressController's namespace and name
 	namespace := "openshift-ingress-operator"
 	name := "default"
-	certName := "ingress-cert"
-
-	err := operatorv1.Install(scheme) // Add operator.openshift.io/v1 to the scheme
-	if err != nil {
-		logger.Error(err, "Failed to install operator.openshift.io/v1")
-		return err
-	}
 
 	ingress := &operatorv1.IngressController{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
@@ -109,7 +102,7 @@ func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context
 		Status:     operatorv1.IngressControllerStatus{},
 	}
 	op, err := controllerutil.CreateOrPatch(ctx, client, ingress, func() error {
-		ingress.Spec.DefaultCertificate = &corev1.LocalObjectReference{Name: certName}
+		ingress.Spec.DefaultCertificate = &corev1.LocalObjectReference{Name: origSecretName}
 		return nil
 	})
 	if err != nil {

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -1,0 +1,47 @@
+package ingress
+
+import (
+	"context"
+
+	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
+	"github.com/go-logr/logr"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func Reconcile(client client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
+
+	// Define the IngressController's namespace and name
+	namespace := "openshift-ingress-operator"
+	name := "default"
+	certName := "ingress-cert"
+
+	err := operatorv1.Install(scheme) // Add operator.openshift.io/v1 to the scheme
+	if err != nil {
+		logger.Error(err, "Failed to install operator.openshift.io/v1")
+		return err
+	}
+
+	ingress := &operatorv1.IngressController{
+		ObjectMeta: v1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec:       operatorv1.IngressControllerSpec{},
+		Status:     operatorv1.IngressControllerStatus{},
+	}
+	op, err := controllerutil.CreateOrPatch(ctx, client, ingress, func() error {
+		ingress.Spec.DefaultCertificate = &corev1.LocalObjectReference{Name: certName}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if op != controllerutil.OperationResultNone {
+		logger.Info("APIServer modified", "OperationResult", op)
+	}
+
+	return nil
+}


### PR DESCRIPTION
This PR will : 
* Confgure certificates with the new domain name, using the configured from CR and if not generate self signed one with the wildcard *.apps.domainname
* Update the `ingresscontrollers.operator.openshift.io` default with the new cert
* Update the `Ingress` object with the new domain name for the console, oauth and downloads endpoings.