### PR TITLE
Add RBAC permissions using kubebuilder comments

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -61,6 +61,13 @@ rules:
   - get
   - patch
 - apiGroups:
+  - config.openshift.io
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - patch
+- apiGroups:
   - machineconfiguration.openshift.io
   resources:
   - machineconfigs
@@ -80,6 +87,13 @@ rules:
   - get
   - update
   - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - ingresscontrollers
+  verbs:
+  - get
+  - patch
 - apiGroups:
   - operators.coreos.com
   resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,6 +6,92 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - get
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - apiservers
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusterversions
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - imagedigestmirrorsets
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - images
+  verbs:
+  - get
+  - patch
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
+  - machineconfigs
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+  - watch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - imagecontentsourcepolicies
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+  - watch
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - rhsyseng.github.io
   resources:
   - clusterrelocations

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -66,15 +66,14 @@ const relocationFinalizer = "relocationfinalizer"
 //+kubebuilder:rbac:groups=rhsyseng.github.io,resources=clusterrelocations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=rhsyseng.github.io,resources=clusterrelocations/finalizers,verbs=update
 
-// Reconcile is part of the main kubernetes reconciliation loop which aims to
-// move the current state of the cluster closer to the desired state.
-// TODO(user): Modify the Reconcile function to compare the state specified by
-// the ClusterRelocation object against the actual cluster state, and then
-// perform operations to make the cluster state reflect the state specified by
-// the user.
-//
-// For more details, check Reconcile and its Result here:
-// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.14.1/pkg/reconcile
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get
+//+kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=watch
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=watch
+//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=watch
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=imagecontentsourcepolicies,verbs=watch
+
 func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -16,6 +16,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;update;get
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=patch;get
+
 func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	var origSecretName string
 	var origSecretNamespace string

--- a/internal/catalog/reconcile.go
+++ b/internal/catalog/reconcile.go
@@ -12,6 +12,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=create;update;get;list;delete
+
 const marketplaceNamespace = "openshift-marketplace"
 
 func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {

--- a/internal/dns/reconcile.go
+++ b/internal/dns/reconcile.go
@@ -33,6 +33,9 @@ type MachineConfigData struct {
 	Storage  MachineConfigStorageData `json:"storage"`
 }
 
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=list
+//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=create;update;get
+
 func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	nodes := &corev1.NodeList{}
 	if err := c.List(ctx, nodes); err != nil {

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -16,6 +16,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;update;get
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=patch;get
+//+kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=patch;get
+
 func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 
 	// Configure certificates with the new domain name for the ingress

--- a/internal/mirror/reconcile.go
+++ b/internal/mirror/reconcile.go
@@ -15,6 +15,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=imagecontentsourcepolicies,verbs=create;update;get;delete
+//+kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=create;update;get;delete
+
 const ImageSetName = "mirror-ocp"
 
 func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger, clusterVersion string) error {

--- a/internal/pullSecret/reconcile.go
+++ b/internal/pullSecret/reconcile.go
@@ -14,6 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;delete
+
 func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	if relocation.Spec.PullSecretRef.Name == "" {
 		// run Cleanup function in case they are moving from PullSecretRef=<something> to PullSecretRef=<empty>

--- a/internal/registryCert/reconcile.go
+++ b/internal/registryCert/reconcile.go
@@ -14,6 +14,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=create;update;get
+//+kubebuilder:rbac:groups=config.openshift.io,resources=images,verbs=patch;get
+
 const ConfigMapName = "generated-registry-cert"
 
 func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -27,6 +27,8 @@ type SecretCopySettings struct {
 	DestinationOwnedByController bool
 }
 
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update
+
 func GetCertCommonName(TLSCertKey []byte) (string, error) {
 	block, _ := pem.Decode(TLSCertKey)
 	if block == nil {

--- a/internal/ssh/reconcile.go
+++ b/internal/ssh/reconcile.go
@@ -29,6 +29,8 @@ type MachineConfigData struct {
 	Passwd   MachineConfigPasswdData `json:"passwd"`
 }
 
+//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=create;update;get;delete
+
 func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	if len(relocation.Spec.SSHKeys) == 0 {
 		return Cleanup(c, ctx, logger)


### PR DESCRIPTION
Fixes https://github.com/RHsyseng/cluster-relocation-operator/issues/28

Adding a comment like:
```
//+kubebuilder:rbac:groups="",resources=secrets,verbs=watch
```

and then running `make manifests` updates the operator's RBAC file with the correct permissions. I'm pretty sure this is how it's meant to be done, this way you can define the RBAC permissions in the same file that they are used in