### PR TITLE
Tweaks to the ingress code

### DIFF
--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -125,6 +125,7 @@ const (
 	PullSecretName       string = "pull-secret"
 	BackupPullSecretName string = "backup-pull-secret"
 	ConfigNamespace      string = "openshift-config"
+	IngressNamespace     string = "openshift-ingress"
 )
 
 const (

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -170,7 +170,6 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 	// Applies a new certificate and domain alias to the Apps ingressesed
 	if err := reconcileIngress.Reconcile(r.Client, r.Scheme, ctx, relocation, logger); err != nil {
-		fmt.Printf("Error while patch ingress controller")
 		ingressCondition := metav1.Condition{
 			Status:             metav1.ConditionFalse,
 			Reason:             rhsysenggithubiov1beta1.ReconciliationFailedReason,
@@ -377,7 +376,7 @@ func (r *ClusterRelocationReconciler) installSchemes() error {
 		return err
 	}
 
-	if err := operatorv1.Install(r.Scheme); err != nil { // Add config.openshift.io/v1 to the scheme
+	if err := operatorv1.Install(r.Scheme); err != nil { // Add operator.openshift.io/v1 to the scheme
 		return err
 	}
 

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -63,7 +63,7 @@ func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, rel
 			return err
 		}
 		if op != controllerutil.OperationResultNone {
-			logger.Info("Self-signed TLS cert modified", "OperationResult", op)
+			logger.Info("Self-signed API TLS cert modified", "OperationResult", op)
 		}
 	} else {
 		origSecretName = relocation.Spec.ApiCertRef.Name
@@ -89,7 +89,7 @@ func Reconcile(c client.Client, scheme *runtime.Scheme, ctx context.Context, rel
 				return err
 			}
 			if op != controllerutil.OperationResultNone {
-				logger.Info(fmt.Sprintf("User provided cert copied to %s", rhsysenggithubiov1beta1.ConfigNamespace), "OperationResult", op)
+				logger.Info(fmt.Sprintf("User provided API cert copied to %s", rhsysenggithubiov1beta1.ConfigNamespace), "OperationResult", op)
 			}
 			origSecretName = secretName
 		}


### PR DESCRIPTION
Mostly just some small cleanup, for example:
```
ingressController := &operatorv1.IngressController{
		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
		Spec:       operatorv1.IngressControllerSpec{},
		Status:     operatorv1.IngressControllerStatus{},
	}
```
when you're patching/getting an object, you just need to provide the name/namespace, the spec/status aren't required (as far as I know).

The main thing I changed: if they are providing their own secret, then we need to copy it twice, once to openshift-ingress and then again to openshift-config, it was only being copied into openshift-ingress