### PR TITLE
Re-create Routes after Ingress is updated

### DIFF
--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -31,13 +31,13 @@ type ClusterRelocationSpec struct {
 	APICertRef *corev1.SecretReference `json:"apiCertRef,omitempty"`
 
 	// CatalogSources define new CatalogSources to install on the cluster.
-	CatalogSources *[]CatalogSource `json:"catalogSources,omitempty"`
+	CatalogSources []CatalogSource `json:"catalogSources,omitempty"`
 
 	// Domain defines the new base domain for the cluster.
 	Domain string `json:"domain"`
 
 	// ImageDigestMirrors is used to configured a mirror registry on the cluster.
-	ImageDigestMirrors *[]configv1.ImageDigestMirrors `json:"imageDigestMirrors,omitempty"`
+	ImageDigestMirrors []configv1.ImageDigestMirrors `json:"imageDigestMirrors,omitempty"`
 
 	// IngressCertRef is a reference to a TLS secret that will be used for the Ingress Controller.
 	// If it is omitted, a self-signed certificate will be generated.
@@ -53,7 +53,7 @@ type ClusterRelocationSpec struct {
 
 	// SSHKeys defines a list of authorized SSH keys for the 'core' user.
 	// If defined, it will be appended to the existing authorized SSH key(s).
-	SSHKeys *[]string `json:"sshKeys,omitempty"`
+	SSHKeys []string `json:"sshKeys,omitempty"`
 }
 
 // ClusterRelocationStatus defines the observed state of ClusterRelocation

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -112,22 +112,14 @@ func (in *ClusterRelocationSpec) DeepCopyInto(out *ClusterRelocationSpec) {
 	}
 	if in.CatalogSources != nil {
 		in, out := &in.CatalogSources, &out.CatalogSources
-		*out = new([]CatalogSource)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]CatalogSource, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]CatalogSource, len(*in))
+		copy(*out, *in)
 	}
 	if in.ImageDigestMirrors != nil {
 		in, out := &in.ImageDigestMirrors, &out.ImageDigestMirrors
-		*out = new([]configv1.ImageDigestMirrors)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]configv1.ImageDigestMirrors, len(*in))
-			for i := range *in {
-				(*in)[i].DeepCopyInto(&(*out)[i])
-			}
+		*out = make([]configv1.ImageDigestMirrors, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.IngressCertRef != nil {
@@ -147,12 +139,8 @@ func (in *ClusterRelocationSpec) DeepCopyInto(out *ClusterRelocationSpec) {
 	}
 	if in.SSHKeys != nil {
 		in, out := &in.SSHKeys, &out.SSHKeys
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -131,3 +131,10 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - route.openshift.io
+  resources:
+  - routes
+  verbs:
+  - delete
+  - list

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"time"
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
 	reconcileApi "github.com/RHsyseng/cluster-relocation-operator/internal/api"
@@ -97,8 +98,12 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			// Run finalization logic for relocationFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
-			if err := r.finalizeRelocation(ctx, logger, relocation); err != nil {
+			requeue, err := r.finalizeRelocation(ctx, logger, relocation)
+			if err != nil {
 				return ctrl.Result{}, err
+			}
+			if requeue {
+				return ctrl.Result{RequeueAfter: time.Second * 20}, nil
 			}
 
 			// Remove relocationFinalizer. Once all finalizers have been
@@ -168,7 +173,8 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	apimeta.SetStatusCondition(&relocation.Status.Conditions, apiCondition)
 
 	// Applies a new certificate and domain alias to the Apps ingressesed
-	if err := reconcileIngress.Reconcile(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
+	requeue, err := reconcileIngress.Reconcile(ctx, r.Client, r.Scheme, relocation, logger)
+	if err != nil {
 		ingressCondition := metav1.Condition{
 			Status:             metav1.ConditionFalse,
 			Reason:             rhsysenggithubiov1beta1.ReconciliationFailedReason,
@@ -179,6 +185,10 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		apimeta.SetStatusCondition(&relocation.Status.Conditions, ingressCondition)
 		return ctrl.Result{}, err
 	}
+	if requeue {
+		return ctrl.Result{RequeueAfter: time.Second * 20}, nil
+	}
+
 	ingressCondition := metav1.Condition{
 		Status:             metav1.ConditionTrue,
 		Reason:             rhsysenggithubiov1beta1.ReconciliationSucceededReason,
@@ -342,25 +352,27 @@ func (r *ClusterRelocationReconciler) updateStatus(ctx context.Context, relocati
 	}
 }
 
-func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, logger logr.Logger, relocation *rhsysenggithubiov1beta1.ClusterRelocation) error {
+func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, logger logr.Logger, relocation *rhsysenggithubiov1beta1.ClusterRelocation) (bool, error) {
+	requeue := false
 	if err := reconcileApi.Cleanup(ctx, r.Client, logger); err != nil {
-		return err
+		return requeue, err
 	}
 
-	if err := reconcileIngress.Cleanup(ctx, r.Client, logger); err != nil {
-		return err
+	requeue, err := reconcileIngress.Cleanup(ctx, r.Client, logger)
+	if err != nil {
+		return requeue, err
 	}
 
 	if err := reconcilePullSecret.Cleanup(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
-		return err
+		return requeue, err
 	}
 
 	if err := registryCert.Cleanup(ctx, r.Client, logger); err != nil {
-		return err
+		return requeue, err
 	}
 
 	logger.Info("Successfully finalized ClusterRelocation")
-	return nil
+	return requeue, nil
 }
 
 func (r *ClusterRelocationReconciler) installSchemes() error {

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -34,6 +34,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 	operatorv1alpha1 "github.com/openshift/api/operator/v1alpha1"
+	routev1 "github.com/openshift/api/route/v1"
 	machineconfigurationv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 	operatorhubv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"golang.org/x/mod/semver"
@@ -380,6 +381,10 @@ func (r *ClusterRelocationReconciler) installSchemes() error {
 	}
 
 	if err := operatorhubv1alpha1.AddToScheme(r.Scheme); err != nil { // Add operators.coreos.com/v1alpha1 to the scheme
+		return err
+	}
+
+	if err := routev1.Install(r.Scheme); err != nil { // Add route.openshift.io/v1 to the scheme
 		return err
 	}
 

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -13,6 +13,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -181,14 +182,14 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		logger.Info("Ingress domain aliases modified", "OperationResult", op)
 	}
 
+	listOptions := client.ListOptions{
+		FieldSelector: fields.ParseSelectorOrDie("metadata.namespace!=openshift-console,metadata.namespace!=openshift-authentication"),
+	}
 	routes := &routev1.RouteList{}
-	if err := c.List(ctx, routes); err != nil {
+	if err := c.List(ctx, routes, &listOptions); err != nil {
 		return err
 	}
 	for _, v := range routes.Items {
-		if v.Namespace == "openshift-console" || v.Namespace == "openshift-authentication" {
-			continue
-		}
 		for _, w := range v.Status.Ingress {
 			if w.RouterName == "default" { // check Routes associated with the default Ingress Controller
 				// TODO: ensure that new domain is ready to go, or else the Route might be re-created with the old domain

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -241,7 +241,7 @@ func resetRoutes(ctx context.Context, c client.Client, domainName string, logger
 					if err := c.Delete(ctx, &v); err != nil {
 						return err
 					}
-					logger.Info("Deleted Route so that it can be re-created with new domain", "Route", v.Name, "namespace", v.Namespace)
+					logger.Info("Deleted Route so that it can be re-created with new domain", "Route", v.Name, "Host", w.Host, "namespace", v.Namespace)
 				}
 			}
 		}

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -144,7 +144,7 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 
 	ingress := &configv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
 	op, err = controllerutil.CreateOrPatch(ctx, c, ingress, func() error {
-		ingress.Spec.AppsDomain = relocation.Spec.Domain
+		ingress.Spec.AppsDomain = fmt.Sprintf("apps.%s", relocation.Spec.Domain)
 		ingress.Spec.ComponentRoutes = []configv1.ComponentRouteSpec{
 			{
 				Hostname:  configv1.Hostname(fmt.Sprintf("console-openshift-console.apps.%s", relocation.Spec.Domain)),

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -181,7 +181,7 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		logger.Info("Ingress domain aliases modified", "OperationResult", op)
 	}
 
-	if err := resetRoutes(ctx, c, relocation.Spec.Domain, logger); err != nil {
+	if err := resetRoutes(ctx, c, fmt.Sprintf("apps.%s", relocation.Spec.Domain), logger); err != nil {
 		return err
 	}
 

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -23,7 +23,7 @@ import (
 //+kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=patch;get
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;delete
 
-func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
+func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) (bool, error) {
 	// Configure certificates with the new domain name for the ingress
 	var origSecretName string
 	var origSecretNamespace string
@@ -65,7 +65,7 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 			return controllerutil.SetControllerReference(relocation, secret, scheme)
 		})
 		if err != nil {
-			return err
+			return false, err
 		}
 		if op != controllerutil.OperationResultNone {
 			logger.Info("Self-signed Ingress TLS cert modified", "OperationResult", op)
@@ -80,14 +80,14 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		}
 		op, err = secrets.CopySecret(ctx, c, relocation, scheme, origSecretName, origSecretNamespace, secretName, rhsysenggithubiov1beta1.ConfigNamespace, copySettings)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if op != controllerutil.OperationResultNone {
 			logger.Info(fmt.Sprintf("Generated Ingress cert copied to %s", rhsysenggithubiov1beta1.ConfigNamespace), "OperationResult", op)
 		}
 	} else {
 		if relocation.Spec.IngressCertRef.Name == "" || relocation.Spec.IngressCertRef.Namespace == "" {
-			return fmt.Errorf("must specify secret name and namespace")
+			return false, fmt.Errorf("must specify secret name and namespace")
 		}
 		origSecretName = relocation.Spec.IngressCertRef.Name
 		origSecretNamespace = relocation.Spec.IngressCertRef.Namespace
@@ -108,7 +108,7 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		}
 		op, err := secrets.CopySecret(ctx, c, relocation, scheme, origSecretName, origSecretNamespace, secretName, rhsysenggithubiov1beta1.IngressNamespace, copySettings)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if op != controllerutil.OperationResultNone {
 			logger.Info(fmt.Sprintf("User provided Ingress cert copied to %s", rhsysenggithubiov1beta1.IngressNamespace), "OperationResult", op)
@@ -117,7 +117,7 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		// Copy the secret into the openshift-config namespace
 		op, err = secrets.CopySecret(ctx, c, relocation, scheme, origSecretName, origSecretNamespace, secretName, rhsysenggithubiov1beta1.ConfigNamespace, copySettings)
 		if err != nil {
-			return err
+			return false, err
 		}
 		if op != controllerutil.OperationResultNone {
 			logger.Info(fmt.Sprintf("User provided Ingress cert copied to %s", rhsysenggithubiov1beta1.ConfigNamespace), "OperationResult", op)
@@ -135,7 +135,7 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		return nil
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if op != controllerutil.OperationResultNone {
@@ -174,23 +174,24 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		return err
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 
 	if op != controllerutil.OperationResultNone {
 		logger.Info("Ingress domain aliases modified", "OperationResult", op)
 	}
 
-	if err := resetRoutes(ctx, c, fmt.Sprintf("apps.%s", relocation.Spec.Domain), logger); err != nil {
-		return err
+	requeue, err := resetRoutes(ctx, c, fmt.Sprintf("apps.%s", relocation.Spec.Domain), logger)
+	if err != nil {
+		return false, err
 	}
 
-	return nil
+	return requeue, nil
 }
 
 // We modified the Ingress Controller and Ingress Cluster resources, but we don't own it
 // Therefore, we need to use a finalizer to put it back the way we found it if the CR is deleted
-func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
+func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) (bool, error) {
 	namespace := "openshift-ingress-operator"
 	name := "default"
 	ingressController := &operatorv1.IngressController{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
@@ -199,7 +200,7 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 		return nil
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	if op != controllerutil.OperationResultNone {
 		logger.Info("Ingress Controller reverted to original state", "OperationResult", op)
@@ -211,39 +212,45 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 		return nil
 	})
 	if err != nil {
-		return err
+		return false, err
 	}
 	if op != controllerutil.OperationResultNone {
 		logger.Info("Ingress cluster reverted to original state", "OperationResult", op)
 	}
 
-	if err := resetRoutes(ctx, c, ingress.Spec.Domain, logger); err != nil { // reset routes to their original domain if needed
-		return err
+	requeue, err := resetRoutes(ctx, c, ingress.Spec.Domain, logger) // reset routes to their original domain if needed
+	if err != nil {
+		return false, err
 	}
 
-	return nil
+	return requeue, nil
 }
 
-func resetRoutes(ctx context.Context, c client.Client, domainName string, logger logr.Logger) error {
+func resetRoutes(ctx context.Context, c client.Client, domainName string, logger logr.Logger) (bool, error) {
+	requeue := false
 	routes := &routev1.RouteList{}
 	if err := c.List(ctx, routes); err != nil {
-		return err
+		return requeue, err
 	}
+
 	for _, v := range routes.Items {
 		if v.Namespace == "openshift-console" || v.Namespace == "openshift-authentication" {
 			continue
 		}
 		for _, w := range v.Status.Ingress {
 			if w.RouterName == "default" { // check Routes associated with the default Ingress Controller
-				// TODO: ensure that new domain is ready to go, or else the Route might be re-created with the old domain
 				if !strings.Contains(w.Host, domainName) { // hostname for this route needs to be updated
 					if err := c.Delete(ctx, &v); err != nil {
-						return err
+						return requeue, err
 					}
+					// if the Ingress hasn't updated yet, the Route may get re-created with the old domain again
+					// to deal with this situation, we requeue the reconciler to run again after a short period of time
+					// when it runs again, it will catch any Routes that are still using the old domain
+					requeue = true
 					logger.Info("Deleted Route so that it can be re-created with new domain", "Route", v.Name, "Host", w.Host, "namespace", v.Namespace)
 				}
 			}
 		}
 	}
-	return nil
+	return requeue, nil
 }

--- a/internal/mirror/reconcile.go
+++ b/internal/mirror/reconcile.go
@@ -51,7 +51,7 @@ func createICSP(ctx context.Context, c client.Client, scheme *runtime.Scheme, re
 	icsp := &operatorv1alpha1.ImageContentSourcePolicy{ObjectMeta: metav1.ObjectMeta{Name: ImageSetName}}
 	op, err := controllerutil.CreateOrUpdate(ctx, c, icsp, func() error {
 		icsp.Spec.RepositoryDigestMirrors = []operatorv1alpha1.RepositoryDigestMirrors{}
-		for _, v := range *relocation.Spec.ImageDigestMirrors {
+		for _, v := range relocation.Spec.ImageDigestMirrors {
 			mirrors := []string{}
 			for _, w := range v.Mirrors {
 				mirrors = append(mirrors, string(w))
@@ -77,7 +77,7 @@ func createICSP(ctx context.Context, c client.Client, scheme *runtime.Scheme, re
 func createIDMS(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	idms := &configv1.ImageDigestMirrorSet{ObjectMeta: metav1.ObjectMeta{Name: ImageSetName}}
 	op, err := controllerutil.CreateOrUpdate(ctx, c, idms, func() error {
-		idms.Spec.ImageDigestMirrors = *relocation.Spec.ImageDigestMirrors
+		idms.Spec.ImageDigestMirrors = relocation.Spec.ImageDigestMirrors
 
 		// Set the controller as the owner so that the IDMS is deleted along with the CR
 		return controllerutil.SetControllerReference(relocation, idms, scheme)

--- a/internal/ssh/reconcile.go
+++ b/internal/ssh/reconcile.go
@@ -46,7 +46,7 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 					Users: []MachineConfigUsersData{
 						{
 							Name:              "core",
-							SSHAuthorizedKeys: *relocation.Spec.SSHKeys,
+							SSHAuthorizedKeys: relocation.Spec.SSHKeys,
 						},
 					},
 				},


### PR DESCRIPTION
I also made another change along the way:

- I realized that the default value for a list/slice is `nil`, so there is no need to make them pointers in the Spec

The Routes need to be deleted so that they can be re-created using the new domain. It's kind of hard to tell when the Ingress has fully updated (when is the right time to delete the Route). To solve this problem: If it deletes a Route, it schedules the Reconciler to run again in 20 seconds. When it runs again, if the Route is back with the old domain again, it'll delete it again.. It will keep doing this until it comes back with the correct domain