### PR TITLE
Wait for API server when reverting

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,6 +70,12 @@ rules:
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:
+  - machineconfigpools
+  verbs:
+  - get
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
   - machineconfigs
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,12 +70,6 @@ rules:
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:
-  - machineconfigpools
-  verbs:
-  - get
-- apiGroups:
-  - machineconfiguration.openshift.io
-  resources:
   - machineconfigs
   verbs:
   - create

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -40,6 +40,12 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusteroperators
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
   - clusterversions
   verbs:
   - get

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -354,11 +354,13 @@ func (r *ClusterRelocationReconciler) updateStatus(ctx context.Context, relocati
 
 func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, logger logr.Logger, relocation *rhsysenggithubiov1beta1.ClusterRelocation) (bool, error) {
 	requeue := false
-	if err := reconcileApi.Cleanup(ctx, r.Client, logger); err != nil {
+
+	requeue, err := reconcileApi.Cleanup(ctx, r.Client, logger)
+	if err != nil {
 		return requeue, err
 	}
 
-	requeue, err := reconcileIngress.Cleanup(ctx, r.Client, logger)
+	requeue, err = reconcileIngress.Cleanup(ctx, r.Client, logger)
 	if err != nil {
 		return requeue, err
 	}

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"time"
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
 	reconcileApi "github.com/RHsyseng/cluster-relocation-operator/internal/api"
@@ -98,13 +97,8 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			// Run finalization logic for relocationFinalizer. If the
 			// finalization logic fails, don't remove the finalizer so
 			// that we can retry during the next reconciliation.
-			requeue, err := r.finalizeRelocation(ctx, logger, relocation)
-			if err != nil {
+			if err := r.finalizeRelocation(ctx, logger, relocation); err != nil {
 				return ctrl.Result{}, err
-			}
-			if requeue {
-				logger.Info("requeuing Reconcile")
-				return ctrl.Result{RequeueAfter: time.Second * 20}, nil
 			}
 
 			// Remove relocationFinalizer. Once all finalizers have been
@@ -174,8 +168,7 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	apimeta.SetStatusCondition(&relocation.Status.Conditions, apiCondition)
 
 	// Applies a new certificate and domain alias to the Apps ingressesed
-	requeue, err := reconcileIngress.Reconcile(ctx, r.Client, r.Scheme, relocation, logger)
-	if err != nil {
+	if err := reconcileIngress.Reconcile(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
 		ingressCondition := metav1.Condition{
 			Status:             metav1.ConditionFalse,
 			Reason:             rhsysenggithubiov1beta1.ReconciliationFailedReason,
@@ -186,11 +179,6 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		apimeta.SetStatusCondition(&relocation.Status.Conditions, ingressCondition)
 		return ctrl.Result{}, err
 	}
-	if requeue {
-		logger.Info("requeuing Reconcile")
-		return ctrl.Result{RequeueAfter: time.Second * 20}, nil
-	}
-
 	ingressCondition := metav1.Condition{
 		Status:             metav1.ConditionTrue,
 		Reason:             rhsysenggithubiov1beta1.ReconciliationSucceededReason,
@@ -355,28 +343,27 @@ func (r *ClusterRelocationReconciler) updateStatus(ctx context.Context, relocati
 	}
 }
 
-func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, logger logr.Logger, relocation *rhsysenggithubiov1beta1.ClusterRelocation) (bool, error) {
+func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, logger logr.Logger, relocation *rhsysenggithubiov1beta1.ClusterRelocation) error {
 	logger.Info("Starting finalizer")
 
 	if err := reconcilePullSecret.Cleanup(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
-		return false, err
+		return err
 	}
 
 	if err := registryCert.Cleanup(ctx, r.Client, logger); err != nil {
-		return false, err
+		return err
+	}
+
+	if err := reconcileIngress.Cleanup(ctx, r.Client, logger); err != nil {
+		return err
 	}
 
 	if err := reconcileApi.Cleanup(ctx, r.Client, logger); err != nil {
-		return false, err
-	}
-
-	requeue, err := reconcileIngress.Cleanup(ctx, r.Client, logger)
-	if err != nil || requeue {
-		return requeue, err
+		return err
 	}
 
 	logger.Info("Successfully finalized ClusterRelocation")
-	return false, nil
+	return nil
 }
 
 func (r *ClusterRelocationReconciler) installSchemes() error {

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -354,6 +354,8 @@ func (r *ClusterRelocationReconciler) updateStatus(ctx context.Context, relocati
 }
 
 func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, logger logr.Logger, relocation *rhsysenggithubiov1beta1.ClusterRelocation) (bool, error) {
+	logger.Info("Starting finalizer")
+
 	if err := reconcilePullSecret.Cleanup(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
 		return false, err
 	}

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -355,21 +355,21 @@ func (r *ClusterRelocationReconciler) updateStatus(ctx context.Context, relocati
 func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, logger logr.Logger, relocation *rhsysenggithubiov1beta1.ClusterRelocation) (bool, error) {
 	requeue := false
 
-	requeue, err := reconcileApi.Cleanup(ctx, r.Client, logger)
-	if err != nil {
-		return requeue, err
-	}
-
-	requeue, err = reconcileIngress.Cleanup(ctx, r.Client, logger)
-	if err != nil {
-		return requeue, err
-	}
-
 	if err := reconcilePullSecret.Cleanup(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
 		return requeue, err
 	}
 
 	if err := registryCert.Cleanup(ctx, r.Client, logger); err != nil {
+		return requeue, err
+	}
+
+	requeue, err := reconcileIngress.Cleanup(ctx, r.Client, logger)
+	if err != nil || requeue {
+		return requeue, err
+	}
+
+	requeue, err = reconcileApi.Cleanup(ctx, r.Client, logger)
+	if err != nil || requeue {
 		return requeue, err
 	}
 

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -317,6 +317,7 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	}
 	apimeta.SetStatusCondition(&relocation.Status.Conditions, dnsCondition)
 
+	logger.Info("Reconcile complete")
 	return ctrl.Result{}, nil
 }
 

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -187,6 +187,7 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, err
 	}
 	if requeue {
+		logger.Info("requeuing Reconcile")
 		return ctrl.Result{RequeueAfter: time.Second * 20}, nil
 	}
 

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -103,6 +103,7 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 				return ctrl.Result{}, err
 			}
 			if requeue {
+				logger.Info("requeuing Reconcile")
 				return ctrl.Result{RequeueAfter: time.Second * 20}, nil
 			}
 

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -130,14 +130,6 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) (bool, er
 		return requeue, err
 	}
 
-	// if the master MCP still contains the DNS configuration, wait to revert the API configuration
-	// rebooting the node while the API server is in the middle of updating can put the API server in a permanently degraded state
-	for _, v := range machineConfigPool.Status.Configuration.Source {
-		if v.Name == "relocation-dns-master" {
-			requeue = true
-		}
-	}
-
 	// if the master MCP is updating, wait to revery the API configuration
 	// rebooting the node while the API server is in the middle of updating can put the API server in a permanently degraded state
 	for _, v := range machineConfigPool.Status.Conditions {

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"time"
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
 	secrets "github.com/RHsyseng/cluster-relocation-operator/internal/secrets"
@@ -131,11 +130,9 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 		return err
 	}
 	if op != controllerutil.OperationResultNone {
-		logger.Info("Waiting for APIServer to update")
-		time.Sleep(time.Minute * 5) // wait for ClusterOperator to start progressing
 		// if we let the finalizer finish before the API server has updated, it will delete a MachineConfig and cause a reboot
 		// if the node reboots before the API server has updated, it can cause the API server to lock up on the next boot
-		if err := util.WaitForAPIOperator(ctx, c, logger); err != nil {
+		if err := util.WaitForCO(ctx, c, logger, "kube-apiserver"); err != nil {
 			return err
 		}
 		logger.Info("APIServer reverted to original state", "OperationResult", op)

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -7,13 +7,11 @@ import (
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
 	secrets "github.com/RHsyseng/cluster-relocation-operator/internal/secrets"
 	"github.com/go-logr/logr"
-	machineconfigurationv1 "github.com/openshift/machine-config-operator/pkg/apis/machineconfiguration.openshift.io/v1"
 
 	configv1 "github.com/openshift/api/config/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -120,39 +118,19 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 	return nil
 }
 
-func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) (bool, error) {
+func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 	// We modified the APIServer resource, but we don't own it
 	// Therefore, we need to use a finalizer to put it back the way we found it if the CR is deleted
-	requeue := false
-
-	machineConfigPool := &machineconfigurationv1.MachineConfigPool{}
-	if err := c.Get(ctx, types.NamespacedName{Name: "master"}, machineConfigPool); err != nil {
-		return requeue, err
-	}
-
-	// if the master MCP is updating, wait to revery the API configuration
-	// rebooting the node while the API server is in the middle of updating can put the API server in a permanently degraded state
-	for _, v := range machineConfigPool.Status.Conditions {
-		if v.Type == machineconfigurationv1.MachineConfigPoolUpdating && v.Status == corev1.ConditionTrue {
-			requeue = true
-		}
-	}
-
-	if requeue {
-		logger.Info("requeuing API cleanup until MachineConfigPool is settled")
-		return requeue, nil
-	}
-
 	apiServer := &configv1.APIServer{ObjectMeta: metav1.ObjectMeta{Name: "cluster"}}
 	op, err := controllerutil.CreateOrPatch(ctx, c, apiServer, func() error {
 		apiServer.Spec.ServingCerts.NamedCertificates = nil
 		return nil
 	})
 	if err != nil {
-		return requeue, err
+		return err
 	}
 	if op != controllerutil.OperationResultNone {
 		logger.Info("APIServer reverted to original state", "OperationResult", op)
 	}
-	return requeue, nil
+	return nil
 }

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -116,6 +116,9 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		if err := util.WaitForCO(ctx, c, logger, "kube-apiserver"); err != nil {
 			return err
 		}
+		if err := util.WaitForCO(ctx, c, logger, "openshift-apiserver"); err != nil {
+			return err
+		}
 		logger.Info("APIServer modified", "OperationResult", op)
 	}
 	return nil
@@ -136,6 +139,9 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 		// if we let the finalizer finish before the API server has updated, it will delete a MachineConfig and cause a reboot
 		// if the node reboots before the API server has updated, it can cause the API server to lock up on the next boot
 		if err := util.WaitForCO(ctx, c, logger, "kube-apiserver"); err != nil {
+			return err
+		}
+		if err := util.WaitForCO(ctx, c, logger, "openshift-apiserver"); err != nil {
 			return err
 		}
 		logger.Info("APIServer reverted to original state", "OperationResult", op)

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -131,6 +131,7 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 		return err
 	}
 	if op != controllerutil.OperationResultNone {
+		logger.Info("Waiting for APIServer to update")
 		time.Sleep(time.Minute * 5) // wait for ClusterOperator to start progressing
 		// if we let the finalizer finish before the API server has updated, it will delete a MachineConfig and cause a reboot
 		// if the node reboots before the API server has updated, it can cause the API server to lock up on the next boot

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -116,9 +116,6 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		if err := util.WaitForCO(ctx, c, logger, "kube-apiserver"); err != nil {
 			return err
 		}
-		if err := util.WaitForCO(ctx, c, logger, "openshift-apiserver"); err != nil {
-			return err
-		}
 		logger.Info("APIServer modified", "OperationResult", op)
 	}
 	return nil
@@ -139,9 +136,6 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 		// if we let the finalizer finish before the API server has updated, it will delete a MachineConfig and cause a reboot
 		// if the node reboots before the API server has updated, it can cause the API server to lock up on the next boot
 		if err := util.WaitForCO(ctx, c, logger, "kube-apiserver"); err != nil {
-			return err
-		}
-		if err := util.WaitForCO(ctx, c, logger, "openshift-apiserver"); err != nil {
 			return err
 		}
 		logger.Info("APIServer reverted to original state", "OperationResult", op)

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -113,6 +113,9 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		return err
 	}
 	if op != controllerutil.OperationResultNone {
+		if err := util.WaitForCO(ctx, c, logger, "kube-apiserver"); err != nil {
+			return err
+		}
 		logger.Info("APIServer modified", "OperationResult", op)
 	}
 	return nil

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -18,7 +18,6 @@ import (
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;update;get
 //+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=patch;get
-//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigpools,verbs=get
 
 func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	var origSecretName string

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -140,6 +140,9 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 	}
 
 	if op != controllerutil.OperationResultNone {
+		if err := util.WaitForCO(ctx, c, logger, "ingress"); err != nil {
+			return err
+		}
 		logger.Info("IngressController modified", "OperationResult", op)
 	}
 
@@ -179,6 +182,9 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 	}
 
 	if op != controllerutil.OperationResultNone {
+		if err := util.WaitForCO(ctx, c, logger, "openshift-apiserver"); err != nil {
+			return err
+		}
 		logger.Info("Ingress domain aliases modified", "OperationResult", op)
 		if err := resetRoutes(ctx, c, fmt.Sprintf("apps.%s", relocation.Spec.Domain), logger); err != nil {
 			return err

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -22,6 +22,7 @@ func WaitForAPIOperator(ctx context.Context, c client.Client, logger logr.Logger
 		coProgressing := true
 		for _, v := range co.Status.Conditions {
 			if v.Type == configv1.OperatorProgressing && v.Status == configv1.ConditionTrue {
+				logger.Info("Waiting for API server to stop progressing")
 				time.Sleep(time.Minute)
 			} else if v.Type == configv1.OperatorProgressing && v.Status == configv1.ConditionFalse {
 				coProgressing = false

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -52,7 +52,7 @@ func waitProgressing(ctx context.Context, c client.Client, logger logr.Logger, o
 			break
 		}
 		// we set a 5 minute timeout in case the operator never gets to Progressing
-		if time.Since(startTime) > time.Minute*5 {
+		if time.Since(startTime) > time.Minute*5 && desired == configv1.ConditionTrue {
 			break
 		}
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -15,26 +15,23 @@ import (
 
 // Waits for the operator to update before returning
 func WaitForCO(ctx context.Context, c client.Client, logger logr.Logger, operator string) error {
-	logger.Info(fmt.Sprintf("Waiting for %s Progressing to be True", operator))
-	if err := waitProgressing(ctx, c, logger, operator, true); err != nil {
+	logger.Info(fmt.Sprintf("Waiting for %s Progressing to be %s", operator, configv1.ConditionTrue))
+	if err := waitProgressing(ctx, c, logger, operator, configv1.ConditionTrue); err != nil {
 		return err
 	}
-	logger.Info(fmt.Sprintf("Waiting for %s Progressing to be False", operator))
-	if err := waitProgressing(ctx, c, logger, operator, false); err != nil {
+	logger.Info(fmt.Sprintf("Waiting for %s Progressing to be %s", operator, configv1.ConditionFalse))
+	if err := waitProgressing(ctx, c, logger, operator, configv1.ConditionFalse); err != nil {
 		return err
 	}
 	return nil
 }
 
-func waitProgressing(ctx context.Context, c client.Client, logger logr.Logger, operator string, progressing bool) error {
+func waitProgressing(ctx context.Context, c client.Client, logger logr.Logger, operator string, desired configv1.ConditionStatus) error {
 	var current configv1.ConditionStatus
-	var desired configv1.ConditionStatus
-	if progressing {
+	if desired == configv1.ConditionTrue {
 		current = configv1.ConditionFalse
-		desired = configv1.ConditionTrue
 	} else {
 		current = configv1.ConditionTrue
-		desired = configv1.ConditionFalse
 	}
 	startTime := time.Now()
 	for {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -13,7 +13,7 @@ import (
 
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get
 
-// Waits for the API server to update before returning
+// Waits for the operator to update before returning
 func WaitForCO(ctx context.Context, c client.Client, logger logr.Logger, operator string) error {
 	logger.Info(fmt.Sprintf("Waiting for %s Progressing to be True", operator))
 	if err := waitProgressing(ctx, c, logger, operator, true); err != nil {
@@ -46,7 +46,7 @@ func waitProgressing(ctx context.Context, c client.Client, logger logr.Logger, o
 		for _, v := range co.Status.Conditions {
 			if v.Type == configv1.OperatorProgressing && v.Status == current {
 				logger.Info(fmt.Sprintf("Still waiting for %s Progressing to be %s", operator, desired))
-				time.Sleep(time.Second * 30)
+				time.Sleep(time.Second * 10)
 			} else if v.Type == configv1.OperatorProgressing && v.Status == desired {
 				desiredStatus = true
 			}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -2,6 +2,7 @@ package util
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -13,22 +14,48 @@ import (
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get
 
 // Waits for the API server to update before returning
-func WaitForAPIOperator(ctx context.Context, c client.Client, logger logr.Logger) error {
+func WaitForCO(ctx context.Context, c client.Client, logger logr.Logger, operator string) error {
+	logger.Info(fmt.Sprintf("Waiting for %s Progressing to be True", operator))
+	if err := waitProgressing(ctx, c, logger, operator, true); err != nil {
+		return err
+	}
+	logger.Info(fmt.Sprintf("Waiting for %s Progressing to be False", operator))
+	if err := waitProgressing(ctx, c, logger, operator, false); err != nil {
+		return err
+	}
+	return nil
+}
+
+func waitProgressing(ctx context.Context, c client.Client, logger logr.Logger, operator string, progressing bool) error {
+	var current configv1.ConditionStatus
+	var desired configv1.ConditionStatus
+	if progressing {
+		current = configv1.ConditionFalse
+		desired = configv1.ConditionTrue
+	} else {
+		current = configv1.ConditionTrue
+		desired = configv1.ConditionFalse
+	}
+	startTime := time.Now()
 	for {
 		co := &configv1.ClusterOperator{}
-		if err := c.Get(ctx, types.NamespacedName{Name: "kube-apiserver"}, co); err != nil {
+		if err := c.Get(ctx, types.NamespacedName{Name: operator}, co); err != nil {
 			return err
 		}
-		coProgressing := true
+		desiredStatus := false
 		for _, v := range co.Status.Conditions {
-			if v.Type == configv1.OperatorProgressing && v.Status == configv1.ConditionTrue {
-				logger.Info("Waiting for API server to stop progressing")
-				time.Sleep(time.Minute)
-			} else if v.Type == configv1.OperatorProgressing && v.Status == configv1.ConditionFalse {
-				coProgressing = false
+			if v.Type == configv1.OperatorProgressing && v.Status == current {
+				logger.Info(fmt.Sprintf("Still waiting for %s Progressing to be %s", operator, desired))
+				time.Sleep(time.Second * 30)
+			} else if v.Type == configv1.OperatorProgressing && v.Status == desired {
+				desiredStatus = true
 			}
 		}
-		if !coProgressing {
+		if desiredStatus {
+			break
+		}
+		// we set a 5 minute timeout in case the operator never gets to Progressing
+		if time.Since(startTime) > time.Minute*5 {
 			break
 		}
 	}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get
+
+// Waits for the API server to update before returning
+func WaitForAPIOperator(ctx context.Context, c client.Client, logger logr.Logger) error {
+	for {
+		co := &configv1.ClusterOperator{}
+		if err := c.Get(ctx, types.NamespacedName{Name: "kube-apiserver"}, co); err != nil {
+			return err
+		}
+		coProgressing := true
+		for _, v := range co.Status.Conditions {
+			if v.Type == configv1.OperatorProgressing && v.Status == configv1.ConditionTrue {
+				time.Sleep(time.Minute)
+			} else if v.Type == configv1.OperatorProgressing && v.Status == configv1.ConditionFalse {
+				coProgressing = false
+			}
+		}
+		if !coProgressing {
+			break
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This PR modifies the ingress and API code a bit so that after a change is made, it waits for the operator to stop progressing before moving on.

If we don't wait for the Ingress, when we delete the existing Routes, they don't get the new domain. We have to wait for the Ingress to update before deleting the Routes, then they get the new domain.

For the API, I noticed that when the CR is deleted, my SNO server fails to bring up the API server after the reboot. If we also wait for the API server to settle after modifying it, things are more stable and the CR can be added/removed without issues