### PR TITLE
Watch requires List

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   verbs:
   - create
   - get
+  - list
   - update
   - watch
 - apiGroups:
@@ -28,6 +29,7 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
   - watch
 - apiGroups:
@@ -57,6 +59,7 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
   - watch
 - apiGroups:
@@ -81,6 +84,7 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
   - watch
 - apiGroups:
@@ -91,6 +95,7 @@ rules:
   - create
   - delete
   - get
+  - list
   - update
   - watch
 - apiGroups:

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -67,13 +67,13 @@ const relocationFinalizer = "relocationfinalizer"
 //+kubebuilder:rbac:groups=rhsyseng.github.io,resources=clusterrelocations/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=rhsyseng.github.io,resources=clusterrelocations/finalizers,verbs=update
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=watch
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=watch
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=watch;list
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=watch;list
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get
-//+kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=watch
-//+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=watch
-//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=watch
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=imagecontentsourcepolicies,verbs=watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=watch;list
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=watch;list
+//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=watch;list
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=imagecontentsourcepolicies,verbs=watch;list
 
 func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)


### PR DESCRIPTION
I tested installing this via the Catalog Source, and these are the errors I saw:

```
W0615 13:50:59.955898       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.5/tools/cache/reflector.go:169: failed to list *v1.MachineConfig: machineconfigs.machineconfiguration.openshift.io is forbidden: User "system:serviceaccount:openshift-operators:cluster-relocation-operator-controller-manager" cannot list resource "machineconfigs" in API group "machineconfiguration.openshift.io" at the cluster scope
E0615 13:50:59.955942       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.5/tools/cache/reflector.go:169: Failed to watch *v1.MachineConfig: failed to list *v1.MachineConfig: machineconfigs.machineconfiguration.openshift.io is forbidden: User "system:serviceaccount:openshift-operators:cluster-relocation-operator-controller-manager" cannot list resource "machineconfigs" in API group "machineconfiguration.openshift.io" at the cluster scope
W0615 13:51:00.882215       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.5/tools/cache/reflector.go:169: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:openshift-operators:cluster-relocation-operator-controller-manager" cannot list resource "secrets" in API group "" at the cluster scope
E0615 13:51:00.882274       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.5/tools/cache/reflector.go:169: Failed to watch *v1.Secret: failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:openshift-operators:cluster-relocation-operator-controller-manager" cannot list resource "secrets" in API group "" at the cluster scope
W0615 13:51:06.414456       1 reflector.go:424] pkg/mod/k8s.io/client-go@v0.26.5/tools/cache/reflector.go:169: failed to list *v1alpha1.ImageContentSourcePolicy: imagecontentsourcepolicies.operator.openshift.io is forbidden: User "system:serviceaccount:openshift-operators:cluster-relocation-operator-controller-manager" cannot list resource "imagecontentsourcepolicies" in API group "operator.openshift.io" at the cluster scope
E0615 13:51:06.414520       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.5/tools/cache/reflector.go:169: Failed to watch *v1alpha1.ImageContentSourcePolicy: failed to list *v1alpha1.ImageContentSourcePolicy: imagecontentsourcepolicies.operator.openshift.io is forbidden: User "system:serviceaccount:openshift-operators:cluster-relocation-operator-controller-manager" cannot list resource "imagecontentsourcepolicies" in API group "operator.openshift.io" at the cluster scope
```

So it seems that the `list` permission is required in order to `watch`