### PR TITLE
Fix a few errors in reconcile

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -38,19 +38,25 @@ rules:
   - apiservers
   verbs:
   - get
+  - list
   - patch
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
   - clusteroperators
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
   - clusterversions
   verbs:
   - get
+  - list
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
@@ -68,14 +74,18 @@ rules:
   - images
   verbs:
   - get
+  - list
   - patch
+  - watch
 - apiGroups:
   - config.openshift.io
   resources:
   - ingresses
   verbs:
   - get
+  - list
   - patch
+  - watch
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:
@@ -104,7 +114,9 @@ rules:
   - ingresscontrollers
   verbs:
   - get
+  - list
   - patch
+  - watch
 - apiGroups:
   - operators.coreos.com
   resources:

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -69,7 +69,7 @@ const relocationFinalizer = "relocationfinalizer"
 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=watch;list
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=watch;list
-//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions,verbs=get;watch;list
 //+kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=watch;list
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=watch;list
 //+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=watch;list

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;update;get
-//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=patch;get
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;update;get;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=patch;get;list;watch
 
 func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	var origSecretName string

--- a/internal/catalog/reconcile.go
+++ b/internal/catalog/reconcile.go
@@ -12,7 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-//+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=create;update;get;list;delete
+//+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=create;update;get;list;delete;watch
 
 const marketplaceNamespace = "openshift-marketplace"
 

--- a/internal/dns/reconcile.go
+++ b/internal/dns/reconcile.go
@@ -34,7 +34,7 @@ type MachineConfigData struct {
 }
 
 //+kubebuilder:rbac:groups="",resources=nodes,verbs=list
-//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=create;update;get
+//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=create;update;get;list;watch
 
 func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	nodes := &corev1.NodeList{}

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -19,9 +19,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;update;get
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=patch;get
-//+kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=patch;get
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create;update;get;list;watch
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=patch;get;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=ingresses,verbs=patch;get;list;watch
 //+kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=list;delete
 
 func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
@@ -186,9 +186,10 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 			return err
 		}
 		logger.Info("Ingress domain aliases modified", "OperationResult", op)
-		if err := resetRoutes(ctx, c, fmt.Sprintf("apps.%s", relocation.Spec.Domain), logger); err != nil {
-			return err
-		}
+	}
+
+	if err := resetRoutes(ctx, c, fmt.Sprintf("apps.%s", relocation.Spec.Domain), logger); err != nil {
+		return err
 	}
 
 	return nil
@@ -229,9 +230,11 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 			return err
 		}
 		logger.Info("Cluster Ingress reverted to original state", "OperationResult", op)
-		if err := resetRoutes(ctx, c, ingress.Spec.Domain, logger); err != nil { // reset routes to their original domain if needed
-			return err
-		}
+
+	}
+
+	if err := resetRoutes(ctx, c, ingress.Spec.Domain, logger); err != nil { // reset routes to their original domain if needed
+		return err
 	}
 
 	return nil

--- a/internal/mirror/reconcile.go
+++ b/internal/mirror/reconcile.go
@@ -15,8 +15,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-//+kubebuilder:rbac:groups=operator.openshift.io,resources=imagecontentsourcepolicies,verbs=create;update;get;delete
-//+kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=create;update;get;delete
+//+kubebuilder:rbac:groups=operator.openshift.io,resources=imagecontentsourcepolicies,verbs=create;update;get;delete;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=imagedigestmirrorsets,verbs=create;update;get;delete;list;watch
 
 const ImageSetName = "mirror-ocp"
 

--- a/internal/pullSecret/reconcile.go
+++ b/internal/pullSecret/reconcile.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;delete
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;delete;list;watch
 
 func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	if relocation.Spec.PullSecretRef == nil {

--- a/internal/registryCert/reconcile.go
+++ b/internal/registryCert/reconcile.go
@@ -14,8 +14,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-//+kubebuilder:rbac:groups="",resources=configmaps,verbs=create;update;get
-//+kubebuilder:rbac:groups=config.openshift.io,resources=images,verbs=patch;get
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=create;update;get;list;watch
+//+kubebuilder:rbac:groups=config.openshift.io,resources=images,verbs=patch;get;list;watch
 
 const ConfigMapName = "generated-registry-cert"
 

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -27,7 +27,7 @@ type SecretCopySettings struct {
 	DestinationOwnedByController bool
 }
 
-//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create;update;list;watch
 
 func GetCertCommonName(TLSCertKey []byte) (string, error) {
 	block, _ := pem.Decode(TLSCertKey)

--- a/internal/ssh/reconcile.go
+++ b/internal/ssh/reconcile.go
@@ -29,7 +29,7 @@ type MachineConfigData struct {
 	Passwd   MachineConfigPasswdData `json:"passwd"`
 }
 
-//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=create;update;get;delete
+//+kubebuilder:rbac:groups=machineconfiguration.openshift.io,resources=machineconfigs,verbs=create;update;get;delete;list;watch
 
 func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	if relocation.Spec.SSHKeys == nil {

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-//+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get
+//+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch
 
 // Waits for the operator to update before returning
 func WaitForCO(ctx context.Context, c client.Client, logger logr.Logger, operator string) error {


### PR DESCRIPTION
It seems like anytime the controller does a `Get`, it uses some caching mechanism that also uses Watch/List:

```
E0615 16:50:41.813418       1 reflector.go:140] pkg/mod/k8s.io/client-go@v0.26.5/tools/cache/reflector.go:169: Failed to watch *v1.IngressController: failed to list *v1.IngressController: ingresscontrollers.operator.openshift.io is forbidden: User "system:serviceaccount:openshift-operators:cluster-relocation-operator-controller-manager" cannot list resource "ingresscontrollers" in API group "operator.openshift.io" at the cluster scope
```

So I've updated the permissions to include `watch` and `list` anytime `get` is used.

Also, because the controller messes with the API server, the controller can crash/close when it is in the middle of its reconcile loop. This meant that `resetRoutes` was missed sometime, since it was configured to only run when the APIServer/Ingress is modified (the controller closes/crashes after modifying the Ingress, so when it runs again, the Ingress isn't modified, and `resetRoutes` never runs).

I've moved `resetRoutes` into the main function, so it will run each time Reconcile runs (it will still only delete Routes when it needs to)