### PR TITLE
Create the openshift-marketplace namespace if it does not exist

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,16 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - nodes
   verbs:
   - list

--- a/internal/catalog/reconcile.go
+++ b/internal/catalog/reconcile.go
@@ -6,6 +6,7 @@ import (
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
 	"github.com/go-logr/logr"
 	operatorhubv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -13,16 +14,30 @@ import (
 )
 
 //+kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=create;update;get;list;delete;watch
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=create;patch;get;list;watch
 
-const marketplaceNamespace = "openshift-marketplace"
+const marketplaceNamespaceName = "openshift-marketplace"
 
 func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	if err := Cleanup(ctx, c, relocation, logger); err != nil {
 		return err
 	}
 
+	marketplaceNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: marketplaceNamespaceName}}
+	op, err := controllerutil.CreateOrPatch(ctx, c, marketplaceNamespace, func() error {
+		marketplaceNamespace.Annotations["workload.openshift.io/allowed"] = "management"
+		marketplaceNamespace.Labels["openshift.io/cluster-monitoring"] = "true"
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if op != controllerutil.OperationResultNone {
+		logger.Info("Created Marketplace namespace", "Namespace", marketplaceNamespaceName, "OperationResult", op)
+	}
+
 	for _, v := range relocation.Spec.CatalogSources {
-		catalogSource := &operatorhubv1alpha1.CatalogSource{ObjectMeta: metav1.ObjectMeta{Name: v.Name, Namespace: marketplaceNamespace}}
+		catalogSource := &operatorhubv1alpha1.CatalogSource{ObjectMeta: metav1.ObjectMeta{Name: v.Name, Namespace: marketplaceNamespaceName}}
 		op, err := controllerutil.CreateOrUpdate(ctx, c, catalogSource, func() error {
 			catalogSource.Spec.Image = v.Image
 			catalogSource.Spec.SourceType = operatorhubv1alpha1.SourceTypeGrpc
@@ -42,7 +57,7 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 func Cleanup(ctx context.Context, c client.Client, relocation *rhsysenggithubiov1beta1.ClusterRelocation, logger logr.Logger) error {
 	// if they remove something from relocation.Spec.CatalogSources, we need to clean it up
 	catalogSources := &operatorhubv1alpha1.CatalogSourceList{}
-	if err := c.List(ctx, catalogSources, client.InNamespace(marketplaceNamespace)); err != nil {
+	if err := c.List(ctx, catalogSources, client.InNamespace(marketplaceNamespaceName)); err != nil {
 		return err
 	}
 	for _, v := range catalogSources.Items { // loop through all existing CatalogSources


### PR DESCRIPTION
If the edge cluster was created with the `marketplace` capability disabled, then the `openshift-marketplace` namespace will not exist. It needs to be created if the user is adding catalogSources