### PR TITLE
Fix dependabot PRs

### DIFF
--- a/.github/workflows/operator.yaml
+++ b/.github/workflows/operator.yaml
@@ -73,11 +73,16 @@ jobs:
 
       - name: Generate operator bundle
         run: |
-          make bundle USE_IMAGE_DIGESTS=true
+          if [[ ${EVENT_NAME} != "pull_request" ]]; then
+            export USE_IMAGE_DIGESTS=true
+          fi
+          make bundle
           echo -e "\n  # Annotations for catalog\n  com.redhat.openshift.versions: \"${{ env.SUPPORTED_OCP_VERSIONS }}\"" >> bundle/metadata/annotations.yaml
           echo -e "\n# Labels for catalog\nLABEL com.redhat.openshift.versions=\"${{ env.SUPPORTED_OCP_VERSIONS }}\"" >> bundle.Dockerfile
           export CONTAINER_IMAGE=$(cat bundle/manifests/cluster-relocation-operator.clusterserviceversion.yaml | yq '.spec.relatedImages | map(select(.name == "manager")) | .[0].image')
           yq -i e ".metadata.annotations.containerImage = \"${CONTAINER_IMAGE}\"" bundle/manifests/cluster-relocation-operator.clusterserviceversion.yaml
+        env:
+          EVENT_NAME: ${{ github.event_name }}
 
       - name: Build operator bundle
         run: |


### PR DESCRIPTION
Externals PRs don't have access to the repo secrets, and thus can't pull things from the Red Hat registry. This should still allow PRs to be tested