### PR TITLE
Ignore some dependabot updates that are managed by SDK upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+      - dependency-name: "k8s.io/apimachinery"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,12 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "sigs.k8s.io/controller-runtime"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+      - dependency-name: "k8s.io/client-go"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"


### PR DESCRIPTION
These dependencies are managed by the SDK, and would get updated when we update the SDK version, see here for example:

https://docs.openshift.com/container-platform/4.13/operators/operator_sdk/golang/osdk-golang-updating-projects.html#osdk-upgrading-projects_osdk-golang-updating-projects