### PR TITLE
skip finalizer if orphaned deletion is requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ spec:
     - <new_ssh_key>
 EOF
 ```
+### Deleting the CR
+When you delete the ClusterRelocation CR, everything will be reverted back to its original state.
+
+If you would like to delete the CR, but keep the relocation configuration, you may add the `skip-finalizer: "true"` annotation:
+```
+apiVersion: rhsyseng.github.io/v1beta1
+kind: ClusterRelocation
+metadata:
+  name: cluster
+  annotations:
+    skip-finalizer: "true"
+```
+and then delete the CR like this:
+```
+oc delete clusterrelocation cluster --cascade=orphan
+```
+This will allow you to delete the CR (and the operator if desired), while keeping the new configuration.
 
 ## Contributing
 This is a community project, feel free to open a PR and help out!

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -135,7 +135,7 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		if err := r.Update(ctx, relocation); err != nil {
 			return ctrl.Result{}, err
 		}
-		logger.Info("Remove finalizer from CR")
+		logger.Info("Removed finalizer from CR")
 	}
 
 	defer r.updateStatus(ctx, relocation, logger)


### PR DESCRIPTION
Fixes https://github.com/RHsyseng/cluster-relocation-operator/issues/67

Some customers may not want this operator hanging around on the cluster forever, once the relocation is complete it is not needed anymore.

This should allow them to delete the ClusterRelocation CR, while retaining everything that it did.