### PR TITLE
Update RBAC for ACM registration

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,9 +18,24 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  - secrets
+  - serviceaccounts
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -30,6 +45,7 @@ rules:
   resources:
   - nodes
   verbs:
+  - get
   - list
   - watch
 - apiGroups:
@@ -50,15 +66,42 @@ rules:
   verbs:
   - create
 - apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
   verbs:
   - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - apps
   resources:
   - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
   verbs:
   - create
 - apiGroups:
@@ -116,6 +159,17 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - machineconfiguration.openshift.io
   resources:
   - machineconfigs
@@ -132,9 +186,19 @@ rules:
   - klusterlets
   verbs:
   - create
+  - delete
   - get
   - list
+  - patch
+  - update
   - watch
+- apiGroups:
+  - operator.open-cluster-management.io
+  resources:
+  - klusterlets/status
+  verbs:
+  - patch
+  - update
 - apiGroups:
   - operator.openshift.io
   resources:
@@ -175,9 +239,37 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
+  - rolebindings
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
   - clusterroles
   verbs:
   - create
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - roles
+  verbs:
+  - bind
+  - create
+  - delete
+  - escalate
+  - get
+  - list
+  - patch
+  - update
+  - watch
 - apiGroups:
   - rhsyseng.github.io
   resources:
@@ -212,3 +304,11 @@ rules:
   - delete
   - list
   - watch
+- apiGroups:
+  - work.open-cluster-management.io
+  resources:
+  - appliedmanifestworks
+  verbs:
+  - list
+  - patch
+  - update

--- a/internal/acm/reconcile.go
+++ b/internal/acm/reconcile.go
@@ -25,15 +25,43 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// these resources are created by the 'crds.yaml' and 'import.yaml' files that are provided by ACM
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=create;delete;get;list;watch
-//+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=klusterlets,verbs=create;get;list;watch
+//+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=klusterlets,verbs=get;list;watch
+
+// these resources are created by the 'crds.yaml' file that is provided by ACM
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create
+
+// these resources are created by the 'import.yaml' file that is provided by ACM
 //+kubebuilder:rbac:groups="",resources=namespaces,verbs=create
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=create
-//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings,verbs=create
-//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=create
+//+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=klusterlets,verbs=create
+
+// these permissions are granted by the ClusterRoles created by import.yaml
+// since an object cannot grant permissions that it doesn't have, the operator needs these as well
+// ClusterRole/klusterlet
+//+kubebuilder:rbac:groups="",resources=secrets;configmaps;serviceaccounts,verbs=create;get;list;update;watch;patch;delete
+//+kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=create;get;list;update;watch;patch
+//+kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=create;get;list;watch;delete
+//+kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+//+kubebuilder:rbac:groups="";events.k8s.io,resources=events,verbs=create;patch;update
+//+kubebuilder:rbac:groups=apps,resources=deployments,verbs=create;get;list;update;watch;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterrolebindings;rolebindings,verbs=create;get;list;update;watch;patch;delete
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;roles,verbs=create;get;list;update;watch;patch;delete;escalate;bind
+//+kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=create;get;list;update;watch;patch;delete
+//+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=klusterlets,verbs=get;list;watch;update;patch;delete
+//+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=klusterlets/status,verbs=update;patch
+//+kubebuilder:rbac:groups=work.open-cluster-management.io,resources=appliedmanifestworks,verbs=list;update;patch
+
+// ClusterRole/klusterlet-bootstrap-kubeconfig
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;update
+
+// ClusterRole/open-cluster-management:klusterlet-admin-aggregate-clusterrole
+//+kubebuilder:rbac:groups=operator.open-cluster-management.io,resources=klusterlets,verbs=get;list;watch;create;update;patch;delete
 
 // returns nil if the Klusterlet is Available, error otherwise
 func checkKlusterlet(ctx context.Context, c client.Client, logger logr.Logger) error {


### PR DESCRIPTION
```
2023-07-07T16:18:03Z	ERROR	Reconciler error	{"controller": "clusterrelocation", "controllerGroup": "rhsyseng.github.io", "controllerKind": "ClusterRelocation", "ClusterRelocation": {"name":"cluster"}, "namespace": "", "name": "cluster", "reconcileID": "3d44fcfb-0e3d-4ae1-ae88-65bbcee00b4e", "error": "clusterroles.rbac.authorization.k8s.io \"klusterlet\" is forbidden: user \"system:serviceaccount:openshift-operators:cluster-relocation-operator-controller-manager\" (groups=[\"system:serviceaccounts\" \"system:serviceaccounts:openshift-operators\" \"system:authenticated\"]) is attempting to grant RBAC permissions not currently held:\n{APIGroups:[\"\"], Resources:[\"events\"], Verbs:[\"update\"]}\n{APIGroups:[\"\"], Resources:[\"namespaces\"], Verbs:[\"delete\"]}\n{APIGroups:[\"\"], Resources:[\"nodes\"], Verbs:[\"get\"]}\n{APIGroups:[\"\"], Resources:[\"secrets\"], Verbs:[\"patch\"]}\n{APIGroups:[\"\"], Resources:[\"serviceaccounts\"], Verbs:[\"get\" \"list\" \"update\" \"watch\" \"patch\" \"delete\"]}\n{APIGroups:[\"apiextensions.k8s.io\"], Resources:[\"customresourcedefinitions\"], Verbs:[\"get\" \"list\" \"update\" \"watch\" \"patch\" \"delete\"]}\n{APIGroups:[\"apps\"], Resources:[\"deployments\"], Verbs:[\"get\" \"list\" \"update\" \"watch\" \"patch\" \"delete\"]}\n{APIGroups:[\"events.k8s.io\"], Resources:[\"events\"], Verbs:[\"create\" \"patch\" \"update\"]}\n{APIGroups:[\"operator.open-cluster-management.io\"], Resources:[\"klusterlets\"], Verbs:[\"update\" \"patch\" \"delete\"]}\n{APIGroups:[\"operator.open-cluster-management.io\"], Resources:[\"klusterlets/status\"], Verbs:[\"update\" \"patch\"]}\n{APIGroups:[\"rbac.authorization.k8s.io\"], Resources:[\"clusterrolebindings\"], Verbs:[\"get\" \"list\" \"update\" \"watch\" \"patch\" \"delete\"]}\n{APIGroups:[\"rbac.authorization.k8s.io\"], Resources:[\"clusterroles\"], Verbs:[\"update\" \"patch\" \"delete\" \"escalate\" \"bind\"]}\n{APIGroups:[\"rbac.authorization.k8s.io\"], Resources:[\"rolebindings\"], Verbs:[\"create\" \"get\" \"list\" \"update\" \"watch\" \"patch\" \"delete\"]}\n{APIGroups:[\"rbac.authorization.k8s.io\"], Resources:[\"roles\"], Verbs:[\"create\" \"get\" \"list\" \"update\" \"watch\" \"patch\" \"delete\" \"escalate\" \"bind\"]}\n{APIGroups:[\"work.open-cluster-management.io\"], Resources:[\"appliedmanifestworks\"], Verbs:[\"list\" \"update\" \"patch\"]}"}
```

```
is attempting to grant RBAC permissions not currently held
```

Registering to ACM involves applying an `import.yaml` file that is provided by ACM. This yaml files includes some ClusterRoles. The operator cannot create these ClusterRoles unless it is already granted the same permissions