### PR TITLE
Update DNS before API and Ingress

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -172,6 +172,14 @@ rules:
 - apiGroups:
   - machineconfiguration.openshift.io
   resources:
+  - machineconfigpools
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - machineconfiguration.openshift.io
+  resources:
   - machineconfigs
   verbs:
   - create

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -159,6 +159,12 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{Requeue: true}, nil
 	}
 
+	// Adds new internal DNS records
+	if err := reconcileDNS.Reconcile(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
+		r.setFailedStatus(relocation, rhsysenggithubiov1beta1.DNSReconciliationFailedReason, err.Error())
+		return ctrl.Result{}, err
+	}
+
 	// Applies a new certificate and domain alias to the API server
 	if err := reconcileAPI.Reconcile(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
 		r.setFailedStatus(relocation, rhsysenggithubiov1beta1.APIReconciliationFailedReason, err.Error())
@@ -204,12 +210,6 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 	// Registers to ACM
 	if err := reconcileACM.Reconcile(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
 		r.setFailedStatus(relocation, rhsysenggithubiov1beta1.ACMReconciliationFailedReason, err.Error())
-		return ctrl.Result{}, err
-	}
-
-	// Adds new internal DNS records
-	if err := reconcileDNS.Reconcile(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
-		r.setFailedStatus(relocation, rhsysenggithubiov1beta1.DNSReconciliationFailedReason, err.Error())
 		return ctrl.Result{}, err
 	}
 


### PR DESCRIPTION
This change makes it so that the internal DNS records are updated for the API and Ingress. In cases where there isn't a local DNS server, this might be important (it might be important that the new API and Ingress URLs can resolve before we try to use them).

As part of this change, I made it so that the operator waits for the MachineConfigPool to update before proceeding (this means the node should reboot and everything before proceeding).