### PR TITLE
Replace skip-finalizer with self-destruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,23 +81,6 @@ spec:
     - <new_ssh_key>
 EOF
 ```
-### Deleting the CR
-When you delete the ClusterRelocation CR, everything will be reverted back to its original state.
-
-If you would like to delete the CR, but keep the relocation configuration, you may add the `skip-finalizer: "true"` annotation:
-```
-apiVersion: rhsyseng.github.io/v1beta1
-kind: ClusterRelocation
-metadata:
-  name: cluster
-  annotations:
-    skip-finalizer: "true"
-```
-and then delete the CR like this:
-```
-oc delete clusterrelocation cluster --cascade=orphan
-```
-This will allow you to delete the CR (and the operator if desired), while keeping the new configuration.
 
 ## Contributing
 This is a community project, feel free to open a PR and help out!

--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ spec:
     - <new_ssh_key>
 EOF
 ```
+### Deleting the CR
+When you delete the ClusterRelocation CR, everything will be reverted back to its original state.
+
+Optionally, you may add the `self-destruct: "true"` annotation when you create the CR:
+```
+apiVersion: rhsyseng.github.io/v1beta1
+kind: ClusterRelocation
+metadata:
+  name: cluster
+  annotations:
+    self-destruct: "true"
+```
+
+This annotation will cause the operator to delete itself (the CR and the Subscription) once the reconciliation has completed, while allowing the cluster to retain all of the new configuration.
+This is useful if you want to remove any operator related overhead on the cluster after the relocation configuration has been applied.
 
 ## Contributing
 This is a community project, feel free to open a PR and help out!

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -231,6 +231,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
   - rbac.authorization.k8s.io
   resources:
   - clusterrolebindings

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -116,26 +116,13 @@ func (r *ClusterRelocationReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, nil
 	}
 
-	skipFinalizer := false
-	val, ok := relocation.Annotations["skip-finalizer"]
-	if ok {
-		if val == "true" {
-			skipFinalizer = true
-		}
-	}
 	// Add finalizer for this CR
-	if !skipFinalizer && !controllerutil.ContainsFinalizer(relocation, relocationFinalizer) {
+	if !controllerutil.ContainsFinalizer(relocation, relocationFinalizer) {
 		controllerutil.AddFinalizer(relocation, relocationFinalizer)
 		if err := r.Update(ctx, relocation); err != nil {
 			return ctrl.Result{}, err
 		}
 		logger.Info("Added finalizer to CR")
-	} else if skipFinalizer && controllerutil.ContainsFinalizer(relocation, relocationFinalizer) {
-		controllerutil.RemoveFinalizer(relocation, relocationFinalizer)
-		if err := r.Update(ctx, relocation); err != nil {
-			return ctrl.Result{}, err
-		}
-		logger.Info("Removed finalizer from CR")
 	}
 
 	defer r.updateStatus(ctx, relocation, logger)

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -280,23 +280,22 @@ func (r *ClusterRelocationReconciler) finalizeRelocation(ctx context.Context, lo
 
 	if r.isSelfDestructSet(relocation) {
 		// TODO: delete Subscription
-		return nil
-	}
+	} else {
+		if err := reconcilePullSecret.Cleanup(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
+			return err
+		}
 
-	if err := reconcilePullSecret.Cleanup(ctx, r.Client, r.Scheme, relocation, logger); err != nil {
-		return err
-	}
+		if err := registryCert.Cleanup(ctx, r.Client, logger); err != nil {
+			return err
+		}
 
-	if err := registryCert.Cleanup(ctx, r.Client, logger); err != nil {
-		return err
-	}
+		if err := reconcileIngress.Cleanup(ctx, r.Client, logger); err != nil {
+			return err
+		}
 
-	if err := reconcileIngress.Cleanup(ctx, r.Client, logger); err != nil {
-		return err
-	}
-
-	if err := reconcileAPI.Cleanup(ctx, r.Client, logger); err != nil {
-		return err
+		if err := reconcileAPI.Cleanup(ctx, r.Client, logger); err != nil {
+			return err
+		}
 	}
 
 	logger.Info("Successfully finalized ClusterRelocation")


### PR DESCRIPTION
I think if someone wants to delete the CR while retaining the changes, they are always also going to want to remove the operator altogether.

This replaces the `skip-finalizer` option with a `self-destruct` option. The `self-destruct` option will automatically remove the CR, and the operator, once the process has completed successfully.

I've tested the deletion of the CR successfully. It's hard to test the deletion of the subscription before this has been pushed to main. Pushing to main will cause the operator/catalog to be pushed to quay, then I can test installing via the catalog/subscription.