### PR TITLE
Delete CSV along with Subscription

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -241,6 +241,12 @@ rules:
 - apiGroups:
   - operators.coreos.com
   resources:
+  - clusterserviceversions
+  verbs:
+  - delete
+- apiGroups:
+  - operators.coreos.com
+  resources:
   - subscriptions
   verbs:
   - delete


### PR DESCRIPTION
I tested the "self-destruct" mode, it deletes the Subscription, but I guess the CSV needs to be deleted as well, see: https://docs.openshift.com/container-platform/4.13/operators/admin/olm-deleting-operators-from-cluster.html#olm-deleting-operator-from-a-cluster-using-cli_olm-deleting-operators-from-a-cluster