### PR TITLE
Validate secret types

### DIFF
--- a/api/v1beta1/clusterrelocation_types.go
+++ b/api/v1beta1/clusterrelocation_types.go
@@ -33,6 +33,7 @@ type ClusterRelocationSpec struct {
 
 	// APICertRef is a reference to a TLS secret that will be used for the API server.
 	// If it is omitted, a self-signed certificate will be generated.
+	// The type of the secret must be kubernetes.io/tls.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	APICertRef *corev1.SecretReference `json:"apiCertRef,omitempty"`
 
@@ -50,11 +51,13 @@ type ClusterRelocationSpec struct {
 
 	// IngressCertRef is a reference to a TLS secret that will be used for the Ingress Controller.
 	// If it is omitted, a self-signed certificate will be generated.
+	// The type of the secret must be kubernetes.io/tls.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	IngressCertRef *corev1.SecretReference `json:"ingressCertRef,omitempty"`
 
 	// PullSecretRef is a reference to new cluster-wide pull secret.
 	// If defined, it will replace the secret located at openshift-config/pull-secret.
+	// The type of the secret must be kubernetes.io/dockerconfigjson.
 	//+operator-sdk:csv:customresourcedefinitions:type=spec
 	PullSecretRef *corev1.SecretReference `json:"pullSecretRef,omitempty"`
 
@@ -138,6 +141,7 @@ type ACMRegistration struct {
 	// It must have a 'token' field. Optionally, it can have a 'ca.crt' field
 	// which provides the CA bundle for the ACM cluster.
 	// The secret is deleted once ACM registration succeeds.
+	// The type of the secret must be Opaque.
 	ACMSecret corev1.SecretReference `json:"acmSecret"`
 
 	// KlusterletAddonConfig is the klusterlet add-on configuration.

--- a/config/crd/bases/rhsyseng.github.io_clusterrelocations.yaml
+++ b/config/crd/bases/rhsyseng.github.io_clusterrelocations.yaml
@@ -44,7 +44,7 @@ spec:
                       for the ACM cluster. It must have a 'token' field. Optionally,
                       it can have a 'ca.crt' field which provides the CA bundle for
                       the ACM cluster. The secret is deleted once ACM registration
-                      succeeds.
+                      succeeds. The type of the secret must be Opaque.
                     properties:
                       name:
                         description: name is unique within a namespace to reference
@@ -240,7 +240,7 @@ spec:
               apiCertRef:
                 description: APICertRef is a reference to a TLS secret that will be
                   used for the API server. If it is omitted, a self-signed certificate
-                  will be generated.
+                  will be generated. The type of the secret must be kubernetes.io/tls.
                 properties:
                   name:
                     description: name is unique within a namespace to reference a
@@ -335,7 +335,7 @@ spec:
               ingressCertRef:
                 description: IngressCertRef is a reference to a TLS secret that will
                   be used for the Ingress Controller. If it is omitted, a self-signed
-                  certificate will be generated.
+                  certificate will be generated. The type of the secret must be kubernetes.io/tls.
                 properties:
                   name:
                     description: name is unique within a namespace to reference a
@@ -350,6 +350,7 @@ spec:
               pullSecretRef:
                 description: PullSecretRef is a reference to new cluster-wide pull
                   secret. If defined, it will replace the secret located at openshift-config/pull-secret.
+                  The type of the secret must be kubernetes.io/dockerconfigjson.
                 properties:
                   name:
                     description: name is unique within a namespace to reference a

--- a/internal/acm/reconcile.go
+++ b/internal/acm/reconcile.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
+	secrets "github.com/RHsyseng/cluster-relocation-operator/internal/secrets"
 	"github.com/go-logr/logr"
 	agentv1 "github.com/stolostron/klusterlet-addon-controller/pkg/apis/agent/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -95,6 +96,10 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 	// skip these steps if the cluster is already registered to ACM
 	if checkKlusterlet(ctx, c, relocation, logger) == nil {
 		return nil
+	}
+
+	if err := secrets.ValidateSecretType(ctx, c, &relocation.Spec.ACMRegistration.ACMSecret, corev1.SecretTypeOpaque); err != nil {
+		return err
 	}
 
 	// the acmSecret holds the credentials for the ACM cluster

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -70,6 +70,10 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		if relocation.Spec.APICertRef.Name == "" || relocation.Spec.APICertRef.Namespace == "" {
 			return fmt.Errorf("must specify secret name and namespace")
 		}
+		if err := secrets.ValidateSecretType(ctx, c, relocation.Spec.APICertRef, corev1.SecretTypeTLS); err != nil {
+			return err
+		}
+
 		origSecretName = relocation.Spec.APICertRef.Name
 		origSecretNamespace = relocation.Spec.APICertRef.Namespace
 		logger.Info("Using user provided API certificate", "namespace", origSecretNamespace, "name", origSecretName)

--- a/internal/ingress/reconcile.go
+++ b/internal/ingress/reconcile.go
@@ -90,6 +90,10 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		if relocation.Spec.IngressCertRef.Name == "" || relocation.Spec.IngressCertRef.Namespace == "" {
 			return fmt.Errorf("must specify secret name and namespace")
 		}
+		if err := secrets.ValidateSecretType(ctx, c, relocation.Spec.IngressCertRef, corev1.SecretTypeTLS); err != nil {
+			return err
+		}
+
 		origSecretName = relocation.Spec.IngressCertRef.Name
 		origSecretNamespace = relocation.Spec.IngressCertRef.Namespace
 		logger.Info("Using user provided Ingress certificate", "namespace", origSecretNamespace, "name", origSecretName)

--- a/internal/pullSecret/reconcile.go
+++ b/internal/pullSecret/reconcile.go
@@ -27,6 +27,10 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		return fmt.Errorf("must specify secret name and namespace")
 	}
 
+	if err := secrets.ValidateSecretType(ctx, c, relocation.Spec.PullSecretRef, corev1.SecretTypeDockerConfigJson); err != nil {
+		return err
+	}
+
 	backupPullSecret := &corev1.Secret{}
 	if err := c.Get(ctx, types.NamespacedName{Name: rhsysenggithubiov1beta1.BackupPullSecretName, Namespace: rhsysenggithubiov1beta1.ConfigNamespace}, backupPullSecret); err != nil {
 		if errors.IsNotFound(err) {

--- a/internal/secrets/secrets.go
+++ b/internal/secrets/secrets.go
@@ -121,3 +121,14 @@ func CopySecret(ctx context.Context, c client.Client, relocation *rhsysenggithub
 
 	return op, err
 }
+
+func ValidateSecretType(ctx context.Context, c client.Client, ref *corev1.SecretReference, desiredSecretType corev1.SecretType) error {
+	secret := &corev1.Secret{}
+	if err := c.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: ref.Namespace}, secret); err != nil {
+		return err
+	}
+	if secret.Type != desiredSecretType {
+		return fmt.Errorf("secret %s is type %s, should be %s", secret.Name, secret.Type, desiredSecretType)
+	}
+	return nil
+}


### PR DESCRIPTION
Fixes https://github.com/RHsyseng/cluster-relocation-operator/issues/78

Add the desired secret types to the CRD, also create a function that will validate the secrets and provide an easy to understand error message, which will show up in the Status of the CR