### PR TITLE
Re-work how we wait for API/Ingress to update

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -132,6 +132,14 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - dnses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - config.openshift.io
+  resources:
   - imagedigestmirrorsets
   verbs:
   - create

--- a/controllers/clusterrelocation_controller.go
+++ b/controllers/clusterrelocation_controller.go
@@ -395,7 +395,9 @@ func (r *ClusterRelocationReconciler) verifyDomain(ctx context.Context, domainNa
 	if err := util.WaitForCO(ctx, r.Client, logger, "openshift-apiserver"); err != nil {
 		return err
 	}
-	reconcileIngress.ResetRoutes(ctx, r.Client, fmt.Sprintf("apps.%s", domainName), logger)
+	if err := reconcileIngress.ResetRoutes(ctx, r.Client, fmt.Sprintf("apps.%s", domainName), logger); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/internal/api/reconcile.go
+++ b/internal/api/reconcile.go
@@ -6,7 +6,6 @@ import (
 
 	rhsysenggithubiov1beta1 "github.com/RHsyseng/cluster-relocation-operator/api/v1beta1"
 	secrets "github.com/RHsyseng/cluster-relocation-operator/internal/secrets"
-	"github.com/RHsyseng/cluster-relocation-operator/internal/util"
 	"github.com/go-logr/logr"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -117,9 +116,6 @@ func Reconcile(ctx context.Context, c client.Client, scheme *runtime.Scheme, rel
 		return err
 	}
 	if op != controllerutil.OperationResultNone {
-		if err := util.WaitForCO(ctx, c, logger, "kube-apiserver", true); err != nil {
-			return err
-		}
 		logger.Info("APIServer modified", "OperationResult", op)
 	}
 	return nil
@@ -137,11 +133,6 @@ func Cleanup(ctx context.Context, c client.Client, logger logr.Logger) error {
 		return err
 	}
 	if op != controllerutil.OperationResultNone {
-		// if we let the finalizer finish before the API server has updated, it will delete a MachineConfig and cause a reboot
-		// if the node reboots before the API server has updated, it can cause the API server to lock up on the next boot
-		if err := util.WaitForCO(ctx, c, logger, "kube-apiserver", true); err != nil {
-			return err
-		}
 		logger.Info("APIServer reverted to original state", "OperationResult", op)
 	}
 	return nil

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -14,14 +14,7 @@ import (
 //+kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch
 
 // Waits for the operator to update before returning
-func WaitForCO(ctx context.Context, c client.Client, logger logr.Logger, operator string, waitProgressingTrue bool) error {
-	if waitProgressingTrue {
-		logger.Info(fmt.Sprintf("Waiting for %s Progressing to be %s", operator, configv1.ConditionTrue))
-		if err := waitStatus(ctx, c, logger, operator, configv1.OperatorProgressing, configv1.ConditionTrue); err != nil {
-			return err
-		}
-	}
-
+func WaitForCO(ctx context.Context, c client.Client, logger logr.Logger, operator string) error {
 	logger.Info(fmt.Sprintf("Waiting for %s Progressing to be %s", operator, configv1.ConditionFalse))
 	if err := waitStatus(ctx, c, logger, operator, configv1.OperatorProgressing, configv1.ConditionFalse); err != nil {
 		return err


### PR DESCRIPTION
Currently, we modify each item, and then verify it, one at a time.

This change makes it so that everything is modified at once, and then the verification happens at the end. This allows things to progress in parallel, rather than serially.

This brings the reconciliation time from around 13 minutes, to around 5 minutes (in my test).