### PR TITLE
allow precreating ACM resources

### DIFF
--- a/docs/ACMRegistration.md
+++ b/docs/ACMRegistration.md
@@ -61,9 +61,9 @@ oc apply -f /tmp/acm-secret.yaml
 Now your target cluster has a Secret than will allow it to authenticate to the ACM cluster and register itself. Once the registration succeeds, the secret is deleted from the target cluster.
 
 ## Pre-creating the ManagedCluster and (optionally) KlusterletAddonConfig
-If you would rather pre-create the ManagedCluster on the ACM cluster, you can omit the `managedClusterSet` and `klusterletAddonConfig` fields from the CR.
+For use cases where flexible and ongoing control over the `ManagedCluster` and (optionally) the `klusterletAddonConfig` CRs is required you may pre-create these artifacts on the ACM hub cluster prior to relocation. This allows the user to control the lifetime and content (eg custom labels on the ManagedCluster) CRs beyond the initial installation phase. 
 
-The Service Account that you create only needs permissions to "get" Secrets for the namespace created by the ManagedCluster.
+When these CRs are pre-created for a cluster you can omit the `managedClusterSet` and `klusterletAddonConfig` fields from the relocation CR. In this case, the Service Account that you create only needs permissions to "get" Secrets for the cluster namespace created by the ManagedCluster.
 
 For example (run these commands on your ACM cluster):
 ```


### PR DESCRIPTION
Add the ability for a user to pre-create the ManagedCluster on the ACM cluster. In this case, the operator will just pull and apply the import secret, and only needs "get secrets" permission within the namespace for the managed cluster.